### PR TITLE
Addressed class loading consistency in AbstractByteCodeLoadingProxy

### DIFF
--- a/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingConsumer.java
+++ b/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingConsumer.java
@@ -23,13 +23,14 @@ import org.springframework.core.io.Resource;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  *
  * @param <T> type
  */
 public class ByteCodeLoadingConsumer<T> extends AbstractByteCodeLoadingProxy<Consumer<T>> implements FunctionFactoryMetadata<Consumer<T>>, Consumer<T> {
 
 	public ByteCodeLoadingConsumer(Resource resource) {
-		super(resource, Consumer.class);
+		super(resource);
 	}
 
 	@Override

--- a/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingFunction.java
+++ b/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingFunction.java
@@ -23,6 +23,7 @@ import org.springframework.core.io.Resource;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  *
  * @param <T> Function input type
  * @param <R> Function result type
@@ -30,7 +31,7 @@ import org.springframework.core.io.Resource;
 public class ByteCodeLoadingFunction<T, R> extends AbstractByteCodeLoadingProxy<Function<T, R>> implements FunctionFactoryMetadata<Function<T, R>>, Function<T, R> {
 
 	public ByteCodeLoadingFunction(Resource resource) {
-		super(resource, Function.class);
+		super(resource);
 	}
 
 	@Override

--- a/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingSupplier.java
+++ b/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingSupplier.java
@@ -23,13 +23,14 @@ import org.springframework.core.io.Resource;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  *
  * @param <T> type
  */
 public class ByteCodeLoadingSupplier<T> extends AbstractByteCodeLoadingProxy<Supplier<T>> implements FunctionFactoryMetadata<Supplier<T>>, Supplier<T> {
 
 	public ByteCodeLoadingSupplier(Resource resource) {
-		super(resource, Supplier.class);
+		super(resource);
 	}
 
 	@Override

--- a/spring-cloud-function-compiler/src/test/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingFunctionTests.java
+++ b/spring-cloud-function-compiler/src/test/java/org/springframework/cloud/function/compiler/proxy/ByteCodeLoadingFunctionTests.java
@@ -36,7 +36,7 @@ import reactor.core.publisher.Flux;
 
 /**
  * @author Dave Syer
- *
+ * @author Oleg Zhurakousky
  */
 public class ByteCodeLoadingFunctionTests {
 
@@ -44,12 +44,7 @@ public class ByteCodeLoadingFunctionTests {
 	public void compileConsumer() throws Exception {
 		CompiledFunctionFactory<Consumer<String>> compiled = new ConsumerCompiler<String>(
 				String.class.getName()).compile("foos", "System.out::println", "String");
-		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos") {
-			@Override
-			public String getFilename() {
-				return "foos.fun";
-			}
-		};
+		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos");
 		ByteCodeLoadingConsumer<String> consumer = new ByteCodeLoadingConsumer<>(resource);
 		consumer.afterPropertiesSet();
 		assertThat(consumer instanceof FunctionFactoryMetadata);
@@ -61,12 +56,7 @@ public class ByteCodeLoadingFunctionTests {
 	public void compileSupplier() throws Exception {
 		CompiledFunctionFactory<Supplier<String>> compiled = new SupplierCompiler<String>(
 				String.class.getName()).compile("foos", "() -> \"foo\"", "String");
-		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos") {
-			@Override
-			public String getFilename() {
-				return "foos.fun";
-			}
-		};
+		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos");
 		ByteCodeLoadingSupplier<String> supplier = new ByteCodeLoadingSupplier<>(resource);
 		supplier.afterPropertiesSet();
 		assertThat(supplier instanceof FunctionFactoryMetadata);
@@ -78,12 +68,7 @@ public class ByteCodeLoadingFunctionTests {
 	public void compileFunction() throws Exception {
 		CompiledFunctionFactory<Function<String, String>> compiled = new FunctionCompiler<String, String>(
 				String.class.getName()).compile("foos", "v -> v.toUpperCase()", "String", "String");
-		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos") {
-			@Override
-			public String getFilename() {
-				return "foos.fun";
-			}
-		};
+		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos");
 		ByteCodeLoadingFunction<String, String> function = new ByteCodeLoadingFunction<>(resource);
 		function.afterPropertiesSet();
 		assertThat(function instanceof FunctionFactoryMetadata);
@@ -95,17 +80,11 @@ public class ByteCodeLoadingFunctionTests {
 	public void compileFluxFunction() throws Exception {
 		CompiledFunctionFactory<Function<Flux<String>, Flux<String>>> compiled = new FunctionCompiler<Flux<String>, Flux<String>>(
 				String.class.getName()).compile("foos", "flux -> flux.map(v -> v.toUpperCase())", "Flux<String>", "Flux<String>");
-		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos") {
-			@Override
-			public String getFilename() {
-				return "foos.fun";
-			}
-		};
+		ByteArrayResource resource = new ByteArrayResource(compiled.getGeneratedClassBytes(), "foos");
 		ByteCodeLoadingFunction<Flux<String>, Flux<String>> function = new ByteCodeLoadingFunction<>(resource);
 		function.afterPropertiesSet();
 		assertThat(function instanceof FunctionFactoryMetadata);
 		assertThat(FunctionFactoryUtils.isFluxFunction(function.getFactoryMethod())).isTrue();
 		assertThat(function.apply(Flux.just("foo")).blockFirst()).isEqualTo("FOO");
 	}
-
 }


### PR DESCRIPTION
- Untill this fix the AbstractByteCodeLoadingProxy was building FQCN of the byte-array defined class using Resource.getFileName() and then some, which is not very reliable since if such name does not match the actual name contained in the byte code, class loading will result in exception. So, this fix reads FQCN from the actual byte code..
- Reduced visibility of AbstractByteCodeLoadingProxy
- Simplified ByteCodeLoadingFunctionTests