### PR TITLE
Fix #87 - normalize to forward slashes

### DIFF
--- a/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/java/CloseableFilterableJavaFileObjectIterable.java
+++ b/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/java/CloseableFilterableJavaFileObjectIterable.java
@@ -46,7 +46,8 @@ public abstract class CloseableFilterableJavaFileObjectIterable implements Itera
 		if (packageNameFilter!=null && packageNameFilter.contains(File.separator)) {
 			throw new IllegalArgumentException("Package name filters should use dots to separate components: "+packageNameFilter);
 		}
-		this.packageNameFilter = packageNameFilter==null?null:packageNameFilter.replace('.', File.separatorChar) + "/";
+		// Normalize filter to forward slashes
+		this.packageNameFilter = packageNameFilter==null?null:packageNameFilter.replace('.', '/') + '/';
 		this.includeSubpackages = includeSubpackages;
 	}
 	
@@ -65,6 +66,8 @@ public abstract class CloseableFilterableJavaFileObjectIterable implements Itera
 			return true;
 		}
 		boolean accept;
+		// Normalize to forward slashes (some jars are producing paths with forward slashes, some with backward slashes)
+		name = name.replace('\\', '/');
 		if (includeSubpackages == true) {
 			accept = name.startsWith(packageNameFilter);
 			if (!accept && BOOT_PACKAGING_AWARE) {

--- a/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/java/CompiledClassDefinition.java
+++ b/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/java/CompiledClassDefinition.java
@@ -33,10 +33,10 @@ public class CompiledClassDefinition {
 		this.filename = filename;
 		this.bytes = bytes;
 		this.classname = filename;
-		if (classname.startsWith(File.separator)) {
+		if (classname.startsWith("/")) {
 			classname = classname.substring(1);
 		}
-		classname = classname.replace(File.separatorChar, '.').substring(0, classname.length()-6);//strip off .class
+		classname = classname.replace('/', '.').substring(0, classname.length()-6); //strip off .class
 	}
 
 	public String getName() {

--- a/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/java/MemoryBasedJavaFileManager.java
+++ b/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/java/MemoryBasedJavaFileManager.java
@@ -136,7 +136,7 @@ public class MemoryBasedJavaFileManager implements JavaFileManager {
 		}
 		// Kind of ignoring location here... assuming we want basically the FQ type name
 		// Example value from getName(): javax/validation/bootstrap/GenericBootstrap.class
-		String classname = file.getName().replace('/', '.');
+		String classname = file.getName().replace('/', '.').replace('\\', '.');
 		return classname.substring(0, classname.lastIndexOf(".class"));
 	}
 


### PR DESCRIPTION
On windows when walking through jar contents some files use
forward slashes and some backslashes. With this change we
switch to a consistent usage of forward slashes throughout
(converting backslashes to forward when necessary). With these
changes the testsuites work on windows.