### PR TITLE
Fix sample path in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -69,7 +69,7 @@ $ ./mvnw clean install
 Run one of the samples, e.g.
 
 ----
-$ java -jar spring-cloud-function-samples/spring-cloud-function-sample/target/*.jar
+$ java -jar spring-cloud-function-samples/function-sample/target/*.jar
 ----
 
 This runs the app and exposes its functions over HTTP, so you can


### PR DESCRIPTION
Use correct path for samples. E.g. look at:

https://github.com/spring-cloud/spring-cloud-function/tree/master/spring-cloud-function-samples