### PR TITLE
GH-118: Properly resolve FactoryBean for function

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/ContextFunctionCatalogAutoConfiguration.java
@@ -34,7 +34,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -73,6 +72,7 @@ import reactor.core.publisher.Flux;
  * @author Dave Syer
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 @FunctionScan
 @Configuration
@@ -197,13 +197,18 @@ public class ContextFunctionCatalogAutoConfiguration {
 	protected static class ContextFunctionRegistry {
 
 		private Map<String, Object> suppliers = new HashMap<>();
+
 		private Map<String, Object> functions = new HashMap<>();
+
 		private Map<String, Object> consumers = new HashMap<>();
 
 		@Autowired
 		private ConfigurableListableBeanFactory registry;
+
 		private ConversionService conversionService;
+
 		private Map<Object, String> registrations = new HashMap<>();
+
 		private Map<String, Map<ParamType, Class<?>>> types = new HashMap<>();
 
 		public Set<String> getSuppliers() {
@@ -507,11 +512,10 @@ public class ContextFunctionCatalogAutoConfiguration {
 			return FunctionInspector
 					.isWrapper(findType(function, ParamType.INPUT_WRAPPER))
 					|| FunctionInspector
-							.isWrapper(findType(function, ParamType.OUTPUT_WRAPPER));
+					.isWrapper(findType(function, ParamType.OUTPUT_WRAPPER));
 		}
 
-		private Class<?> findType(String name, AbstractBeanDefinition definition,
-				ParamType paramType) {
+		private Class<?> findType(String name, AbstractBeanDefinition definition, ParamType paramType) {
 			Object source = definition.getSource();
 			Type param = null;
 			// Start by assuming output -> Function
@@ -535,17 +539,10 @@ public class ContextFunctionCatalogAutoConfiguration {
 				param = extractType(type, paramType, index);
 			}
 			else if (source instanceof Resource) {
-				try {
-					Class<?> beanType = resolveBeanClass(definition);
-					param = findTypeFromBeanClass(beanType, paramType);
-					if (param == null) {
-						// Last chance
-						param = beanType;
-					}
-				}
-				catch (ClassNotFoundException e) {
-					throw new IllegalStateException(
-							"Cannot instrospect bean: " + definition, e);
+				Class<?> beanType = this.registry.getType(name);
+				param = findTypeFromBeanClass(beanType, paramType);
+				if (param == null) {
+					return Object.class;
 				}
 			}
 			else {
@@ -554,8 +551,8 @@ public class ContextFunctionCatalogAutoConfiguration {
 				if (resolvable != null) {
 					param = resolvable.getGeneric(index).getGeneric(0).getType();
 				}
-				else if (registry instanceof BeanFactory) {
-					Object bean = ((BeanFactory) registry).getBean(name);
+				else {
+					Object bean = this.registry.getBean(name);
 					if (bean instanceof FunctionFactoryMetadata) {
 						FunctionFactoryMetadata<?> factory = (FunctionFactoryMetadata<?>) bean;
 						Type type = factory.getFactoryMethod().getGenericReturnType();
@@ -563,8 +560,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 					}
 				}
 			}
-			Class<?> result = extractClass(name, param, paramType);
-			return result;
+			return extractClass(name, param, paramType);
 		}
 
 		private Class<?> extractClass(String name, Type param, ParamType paramType) {
@@ -681,7 +677,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 			return Message.class
 					.isAssignableFrom(findType(function, ParamType.INPUT_INNER_WRAPPER))
 					|| Message.class.isAssignableFrom(
-							findType(function, ParamType.OUTPUT_INNER_WRAPPER));
+					findType(function, ParamType.OUTPUT_INNER_WRAPPER));
 		}
 
 		private Class<?> findType(Object function, ParamType type) {
@@ -710,7 +706,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 		}
 	}
 
-	static enum ParamType {
+	enum ParamType {
 		INPUT, OUTPUT, INPUT_WRAPPER, OUTPUT_WRAPPER, INPUT_INNER_WRAPPER, OUTPUT_INNER_WRAPPER;
 
 		public boolean isOutput() {

--- a/spring-cloud-function-samples/function-sample/src/main/resources/META-INF/thin-file.properties
+++ b/spring-cloud-function-samples/function-sample/src/main/resources/META-INF/thin-file.properties
@@ -1,0 +1,3 @@
+hboms.spring-cloud-dependencies: org.springframework.cloud:spring-cloud-dependencies:Dalston.SR4
+dependencies.spring-cloud-function-stream: org.springframework.cloud:spring-cloud-function-stream:1.0.0.BUILD-SNAPSHOT
+dependencies.spring-cloud-stream-file: org.springframework.cloud:spring-cloud-stream-binder-file:1.0.0.BUILD-SNAPSHOT

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/DefaultStreamListener.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/DefaultStreamListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.stream;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.annotation.Output;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default configuration class for listening to streams and invoking functions (and
+ * consumers). If an application has an <code>@EnableBinding</code> for any other
+ * interface it can copy this code and change the name of the interface (from
+ * {@link Processor} to whatever is appropriate to the application).
+ * 
+ * @author Dave Syer
+ *
+ */
+@Configuration
+@EnableBinding(Processor.class)
+@ConditionalOnProperty(prefix = "spring.cloud.function.stream", value = "defaultBindingsEnabled", matchIfMissing = true)
+public class DefaultStreamListener {
+	@StreamListener
+	public Mono<Void> handle(@Input(Processor.INPUT) Flux<Message<?>> input,
+			@Output(Processor.OUTPUT) FunctionInvoker output) {
+		return output.send(input);
+	}
+}

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/FunctionInvoker.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/FunctionInvoker.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.stream;
+
+import org.springframework.messaging.Message;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public interface FunctionInvoker {
+
+	Mono<Void> send(Flux<Message<?>> input);
+
+}

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/MessageChannelToFunctionInvokerParameterAdapter.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/MessageChannelToFunctionInvokerParameterAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.stream.config;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.cloud.function.stream.FunctionInvoker;
+import org.springframework.cloud.stream.binding.StreamListenerParameterAdapter;
+import org.springframework.cloud.stream.reactive.FluxSender;
+import org.springframework.cloud.stream.reactive.MessageChannelToFluxSenderParameterAdapter;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class MessageChannelToFunctionInvokerParameterAdapter
+		implements StreamListenerParameterAdapter<FunctionInvoker, MessageChannel> {
+
+	private StreamListeningFunctionInvoker invoker;
+	private final BeanFactory beanFactory;
+	private final MessageChannelToFluxSenderParameterAdapter adapter;
+
+	public MessageChannelToFunctionInvokerParameterAdapter(
+			BeanFactory beanFactory,
+			MessageChannelToFluxSenderParameterAdapter adapter) {
+		this.beanFactory = beanFactory;
+		this.adapter = adapter;
+	}
+
+	@Override
+	public boolean supports(Class<?> bindingTargetType, MethodParameter methodParameter) {
+		ResolvableType type = ResolvableType.forMethodParameter(methodParameter);
+		return MessageChannel.class.isAssignableFrom(bindingTargetType)
+				&& FunctionInvoker.class.isAssignableFrom(type.getRawClass());
+	}
+
+	@Override
+	public FunctionInvoker adapt(MessageChannel bindingTarget,
+			MethodParameter parameter) {
+		MethodParameter actual = new MethodParameter(
+				ReflectionUtils.findMethod(getClass(), "dummy", FluxSender.class), 0);
+		return input -> invoker().handle(input, adapter.adapt(bindingTarget, actual));
+	}
+
+	private StreamListeningFunctionInvoker invoker() {
+		if (this.invoker==null) {
+			// Lazy lookup of invoker to prevent cascade of instantiation 
+			this.invoker = beanFactory.getBean(StreamListeningFunctionInvoker.class);
+		}
+		return this.invoker;
+	}
+
+	public void dummy(FluxSender sender) {
+
+	}
+
+}

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/StreamAutoConfiguration.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/StreamAutoConfiguration.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.function.stream;
+package org.springframework.cloud.function.stream.config;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -23,11 +24,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.function.context.FunctionInspector;
 import org.springframework.cloud.function.core.FunctionCatalog;
-import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.function.stream.DefaultStreamListener;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
-import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.reactive.MessageChannelToFluxSenderParameterAdapter;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 
 /**
@@ -38,11 +40,17 @@ import org.springframework.context.annotation.Lazy;
 @ConditionalOnClass(Binder.class)
 @ConditionalOnBean(FunctionCatalog.class)
 @ConditionalOnProperty(name = "spring.cloud.stream.enabled", havingValue = "true", matchIfMissing = true)
-@EnableBinding(Processor.class)
-public class StreamConfiguration {
+@Import(DefaultStreamListener.class)
+public class StreamAutoConfiguration {
 
 	@Autowired
 	private StreamConfigurationProperties properties;
+
+	@Bean
+	public MessageChannelToFunctionInvokerParameterAdapter messageChannelToFunctionInvokerParameterAdapter(
+			BeanFactory beanFactory, MessageChannelToFluxSenderParameterAdapter adapter) {
+		return new MessageChannelToFunctionInvokerParameterAdapter(beanFactory, adapter);
+	}
 
 	@Bean
 	// Because of the underlying behaviour of Spring AMQP etc., sources do not start

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/StreamConfigurationProperties.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/StreamConfigurationProperties.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.function.stream;
+package org.springframework.cloud.function.stream.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -35,6 +35,11 @@ public class StreamConfigurationProperties {
 	 * Supplier. Default is 0, which means the Supplier will only be invoked once.
 	 */
 	private long interval = 0L;
+	
+	/**
+	 * Flag to say that the default bindings to "input" and "output" are to be enabled.
+	 */
+	private boolean defaultBindingsEnabled = true;
 
 	public static final String ROUTE_KEY = "stream_routekey";
 
@@ -52,5 +57,13 @@ public class StreamConfigurationProperties {
 
 	public void setInterval(long interval) {
 		this.interval = interval;
+	}
+
+	public boolean isDefaultBindingsEnabled() {
+		return this.defaultBindingsEnabled;
+	}
+
+	public void setDefaultBindingsEnabled(boolean defaultBindingsEnabled) {
+		this.defaultBindingsEnabled = defaultBindingsEnabled;
 	}
 }

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/StreamListeningFunctionInvoker.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/StreamListeningFunctionInvoker.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.function.stream;
+package org.springframework.cloud.function.stream.config;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,11 +28,7 @@ import java.util.function.Function;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.cloud.function.context.FunctionInspector;
 import org.springframework.cloud.function.core.FunctionCatalog;
-import org.springframework.cloud.stream.annotation.Input;
-import org.springframework.cloud.stream.annotation.Output;
-import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
-import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.reactive.FluxSender;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConverter;
@@ -79,9 +75,7 @@ public class StreamListeningFunctionInvoker implements SmartInitializingSingleto
 		this.converter = this.converterFactory.getMessageConverterForAllRegistered();
 	}
 
-	@StreamListener
-	public Mono<Void> handle(@Input(Processor.INPUT) Flux<Message<?>> input,
-			@Output(Processor.OUTPUT) FluxSender output) {
+	public Mono<Void> handle(Flux<Message<?>> input, FluxSender output) {
 		return output.send(
 				input.groupBy(this::select).flatMap(group -> group.key().process(group)));
 	}
@@ -137,7 +131,7 @@ public class StreamListeningFunctionInvoker implements SmartInitializingSingleto
 					.get(StreamConfigurationProperties.ROUTE_KEY);
 			name = stash(key);
 		}
-		if (name==null && defaultRoute != null) {
+		if (name == null && defaultRoute != null) {
 			name = stash(defaultRoute);
 		}
 		if (name == null) {
@@ -151,10 +145,10 @@ public class StreamListeningFunctionInvoker implements SmartInitializingSingleto
 			else {
 				for (String candidate : names) {
 					Object function = functionCatalog.lookupFunction(candidate);
-					if (function==null) {
+					if (function == null) {
 						function = functionCatalog.lookupConsumer(candidate);
 					}
-					if (function==null) {
+					if (function == null) {
 						continue;
 					}
 					Class<?> inputType = functionInspector.getInputType(function);

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/SupplierInvokingMessageProducer.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/config/SupplierInvokingMessageProducer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.function.stream;
+package org.springframework.cloud.function.stream.config;
 
 import java.util.function.Supplier;
 

--- a/spring-cloud-function-stream/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-function-stream/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.function.stream.StreamConfiguration
+org.springframework.cloud.function.stream.config.StreamAutoConfiguration

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/mixed/PojoStreamingExplicitEndpointTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/mixed/PojoStreamingExplicitEndpointTests.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.function.stream.StreamConfigurationProperties;
+import org.springframework.cloud.function.stream.config.StreamConfigurationProperties;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.annotation.Bean;

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/mixed/PojoStreamingMixedTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/mixed/PojoStreamingMixedTests.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.function.stream.StreamConfigurationProperties;
+import org.springframework.cloud.function.stream.config.StreamConfigurationProperties;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.annotation.Bean;

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/supplier/StreamSupplierTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/supplier/StreamSupplierTests.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.function.stream.StreamConfigurationProperties;
+import org.springframework.cloud.function.stream.config.StreamConfigurationProperties;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
Fixes: spring-cloud/spring-cloud-function#118

When the `BeanDefinition` for `Function` is a `FactoryBean`
(e.g. `GatewayProxyFactoryBean` in Spring Integration) and that
`BeanDefinition` isn't registered as `@Bean` method (e.g.
Spring Integration Java DSL parser), the `ContextFunctionCatalogAutoConfiguration`
doesn't resolve the target `Function` type properly

* Get the target `Function` bean type via `BeanFactory.getType(String)`
* Make fallback to the `Object.class` instead of bean type since we are
expecting here a generic type anyway