### PR TITLE
ContextFunctionRegistry is not thread-safe

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -172,11 +173,11 @@ public class ContextFunctionCatalogAutoConfiguration {
 	@Component
 	protected static class ContextFunctionRegistry {
 
-		private Map<String, Object> suppliers = new HashMap<>();
+		private Map<String, Object> suppliers = new ConcurrentHashMap<>();
 
-		private Map<String, Object> functions = new HashMap<>();
+		private Map<String, Object> functions = new ConcurrentHashMap<>();
 
-		private Map<String, Object> consumers = new HashMap<>();
+		private Map<String, Object> consumers = new ConcurrentHashMap<>();
 
 		@Autowired(required = false)
 		private ApplicationEventPublisher publisher;
@@ -184,9 +185,9 @@ public class ContextFunctionCatalogAutoConfiguration {
 		@Autowired
 		private ConfigurableListableBeanFactory registry;
 
-		private Map<Object, String> names = new HashMap<>();
+		private Map<Object, String> names = new ConcurrentHashMap<>();
 
-		private Map<String, FunctionType> types = new HashMap<>();
+		private Map<String, FunctionType> types = new ConcurrentHashMap<>();
 
 		public Set<String> getSuppliers() {
 			return this.suppliers.keySet();


### PR DESCRIPTION
`ContextFunctionRegistry` uses `HashMap` to store functions by name, etc. It is used concurrently if functions are called from multiple HTTP threads. I'm not sure if `HashMap` will break if it's only queried from multiple threads (and not modified upon initialization), but better be safe than sorry.