### PR TITLE
Fix possible NPE in FunctionHandlerMapping

### DIFF
--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/mvc/FunctionHandlerMapping.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/mvc/FunctionHandlerMapping.java
@@ -83,14 +83,14 @@ public class FunctionHandlerMapping extends RequestMappingHandlerMapping
 		}
 		String path = (String) request
 				.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+		if (path == null) {
+			return handler;
+		}
 		if (StringUtils.hasText(prefix) && !path.startsWith(prefix)) {
 			return null;
 		}
 		if (path.startsWith(prefix)) {
 			path = path.substring(prefix.length());
-		}
-		if (path == null) {
-			return handler;
 		}
 		Object function = findFunctionForGet(request, path);
 		if (function != null) {


### PR DESCRIPTION
Happens when `HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTES` is null
Can be seen when using spring-boot-starter-actuator with a scanned function
The path is `null` because the request wrapped by the `WebMvcMetricsFilter` is unmodifiable,
so setting the attribute in `AbstractHandlerMethodMapping#handleMatch` has no effect