### PR TITLE
GH-258, Avoid duplicate registration of functional bean

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionalSpringApplication.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionalSpringApplication.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.function.context;
 
+import static java.util.Arrays.stream;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +26,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextInitializer;
@@ -122,6 +125,13 @@ public class FunctionalSpringApplication
 								() -> new FunctionRegistration<>(
 										handler(generic, function, functionType))
 												.type(FunctionType.of(functionType)));
+						if (source.equals(functionType)) {
+							context.addBeanFactoryPostProcessor(beanFactory -> {
+								BeanDefinitionRegistry bdRegistry = (BeanDefinitionRegistry) beanFactory;
+								stream(beanFactory.getBeanNamesForType(functionType))
+										.forEach(bdRegistry::removeBeanDefinition);
+							});
+						}
 						functional = true;
 					}
 				}


### PR DESCRIPTION
Added logic in FunctionalSpringApplication to avoid registering the functional bean twice.  This issue occured when executing in "hybrid" mode, and using the same bean as both the application context source and functional bean.

FIXES #258 