### PR TITLE
Simple refactor: isSingleInput already check if input is a collection

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/main/java/org/springframework/cloud/function/adapter/azure/AzureSpringBootRequestHandler.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/main/java/org/springframework/cloud/function/adapter/azure/AzureSpringBootRequestHandler.java
@@ -92,9 +92,7 @@ public class AzureSpringBootRequestHandler<I, O> extends AbstractSpringFunctionA
 
 	protected Flux<?> extract(Object input) {
 		if (!isSingleInput(this.getFunction(), input)) {
-			if (input instanceof Collection) {
-				return Flux.fromIterable((Iterable<?>) input);
-			}
+			return Flux.fromIterable((Iterable<?>) input);
 		}
 		return Flux.just(input);
 	}


### PR DESCRIPTION
A really simple refactor on AzureSpringBootRequestHandler: isSingleInput already check if input is a collection.