### PR TITLE
GH-258 avoid registering duplicate functional bean (second attempt)

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionalSpringApplication.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionalSpringApplication.java
@@ -125,20 +125,15 @@ public class FunctionalSpringApplication
 					|| Supplier.class.isAssignableFrom(type)) {
 				Class<?> functionType = type;
 				Object function = handler;
+				this.register((GenericApplicationContext) context, function, functionType);
 				if (source.equals(functionType)) {
 					context.addBeanFactoryPostProcessor(beanFactory -> {
 						BeanDefinitionRegistry bdRegistry = (BeanDefinitionRegistry) beanFactory;
 						if (!ObjectUtils.isEmpty(context.getBeanNamesForType(functionType))) {
 							stream(context.getBeanNamesForType(functionType))
-							.forEach(beanName -> bdRegistry.registerAlias(beanName, "function"));
-						}
-						else {
-							this.register((GenericApplicationContext) context, function, functionType);
+								.forEach(bdRegistry::removeBeanDefinition);
 						}
 					});
-				}
-				else {
-					this.register((GenericApplicationContext) context, function, functionType);
 				}
 				functional = true;
 			}

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/HybridFunctionalRegistrationTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/HybridFunctionalRegistrationTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Semyon Fishman
  *
  */
 public class HybridFunctionalRegistrationTests {
@@ -41,8 +42,10 @@ public class HybridFunctionalRegistrationTests {
 	public void testNoDoubleRegistrationInHybridMode() {
 		ConfigurableApplicationContext context = FunctionalSpringApplication
 				.run(UppercaseFunction.class, "--spring.functional.enabled=false");
+		FunctionCatalog catalog = context.getBean(FunctionCatalog.class);
+
 		assertThat(context.containsBean("function")).isTrue();
-		assertThat(context.getBeansOfType(UppercaseFunction.class).size()).isEqualTo(1);
+		assertThat(catalog.size()).isEqualTo(1);
 	}
 
 	@SpringBootConfiguration
@@ -54,13 +57,7 @@ public class HybridFunctionalRegistrationTests {
 
 		@Override
 		public String apply(String t) {
-			System.out.println("Receoved " + t);
-			return t;
-		}
-
-		@Bean
-		public Function<String, String> foo() {
-			return x -> x;
+			return t.toUpperCase();
 		}
 	}
 


### PR DESCRIPTION
I already fixed GH-258 in [PR-259](https://github.com/spring-cloud/spring-cloud-function/pull/259), but it appears it broke again in [94106d](https://github.com/spring-cloud/spring-cloud-function/commit/94106d).

Let me review the issue here once again for clarity, the scenario is:
- executing in **hybrid** mode,
- registering exactly **one** function (like in AWS Lambda environment)
- and using the _same_ class for both function **definition** and **configuration** (like I show in GH-258)

The issue then arises from the following set of consequences:
1. this class gets registered **twice**, once as the application context _source_ (named after the class name) and once as the _function_ (named "function")
2. this in turn registers **two** separate functions with the `FunctionCatalog`, 
3. and that confuses the `AbstractSpringFunctionAdapterInitializer`, which has logic to default to the only one registered function (or consumer or supplier), when there is only one registered. But because of this issue, the function is registered twice resulting in AbstractSpringFunctionAdapterInitializer not finding it.

I updated `HybridFunctionalRegistrationTests` to show this issue. 

### Also see  PR-316
An alternative way to fix this is to update the logic in AbstractSpringFunctionAdapterInitializer, which I did in PR-316.  

Note that only **one** of these two PR's is necessary to fix this issue; I'll let you choose which one, but I think PR-316 might actually be a better idea.