### PR TITLE
URL Cleanup

### DIFF
--- a/.flattened-pom.xml
+++ b/.flattened-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="https://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud</groupId>
   <artifactId>spring-cloud-function-parent</artifactId>
@@ -40,7 +40,7 @@ limitations under the License.</comments>
       <name>Dave Syer</name>
       <email>dsyer at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -50,7 +50,7 @@ limitations under the License.</comments>
       <name>Spencer Gibb</name>
       <email>sgibb at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -60,7 +60,7 @@ limitations under the License.</comments>
       <name>Marcin Grzejszczak</name>
       <email>mgrzejszczak at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>
@@ -70,7 +70,7 @@ limitations under the License.</comments>
       <name>Ryan Baxter</name>
       <email>rbaxter at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>

--- a/docs/.flattened-pom.xml
+++ b/docs/.flattened-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="https://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud</groupId>
   <artifactId>spring-cloud-function-docs</artifactId>
@@ -40,7 +40,7 @@ limitations under the License.</comments>
       <name>Dave Syer</name>
       <email>dsyer at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -50,7 +50,7 @@ limitations under the License.</comments>
       <name>Spencer Gibb</name>
       <email>sgibb at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -60,7 +60,7 @@ limitations under the License.</comments>
       <name>Marcin Grzejszczak</name>
       <email>mgrzejszczak at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>
@@ -70,7 +70,7 @@ limitations under the License.</comments>
       <name>Ryan Baxter</name>
       <email>rbaxter at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>

--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="http://www.w3.org/2000/svg">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="https://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
 <font id="fontawesomeregular" horiz-adv-x="1536" >

--- a/spring-cloud-function.xml
+++ b/spring-cloud-function.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Function</title>
 <date>2019-03-14</date>
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-starter-function-web/.flattened-pom.xml
+++ b/spring-cloud-starter-function-web/.flattened-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="https://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud</groupId>
   <artifactId>spring-cloud-starter-function-web</artifactId>
@@ -39,7 +39,7 @@ limitations under the License.</comments>
       <name>Dave Syer</name>
       <email>dsyer at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -49,7 +49,7 @@ limitations under the License.</comments>
       <name>Spencer Gibb</name>
       <email>sgibb at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -59,7 +59,7 @@ limitations under the License.</comments>
       <name>Marcin Grzejszczak</name>
       <email>mgrzejszczak at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>
@@ -69,7 +69,7 @@ limitations under the License.</comments>
       <name>Ryan Baxter</name>
       <email>rbaxter at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>

--- a/spring-cloud-starter-function-webflux/.flattened-pom.xml
+++ b/spring-cloud-starter-function-webflux/.flattened-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="https://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud</groupId>
   <artifactId>spring-cloud-starter-function-webflux</artifactId>
@@ -39,7 +39,7 @@ limitations under the License.</comments>
       <name>Dave Syer</name>
       <email>dsyer at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -49,7 +49,7 @@ limitations under the License.</comments>
       <name>Spencer Gibb</name>
       <email>sgibb at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>lead</role>
       </roles>
@@ -59,7 +59,7 @@ limitations under the License.</comments>
       <name>Marcin Grzejszczak</name>
       <email>mgrzejszczak at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>
@@ -69,7 +69,7 @@ limitations under the License.</comments>
       <name>Ryan Baxter</name>
       <email>rbaxter at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://maven.apache.org/POM/4.0.0 (404) with 8 occurrences migrated to:  
  https://maven.apache.org/POM/4.0.0 ([https](https://maven.apache.org/POM/4.0.0) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docbook.org/ns/docbook with 1 occurrences migrated to:  
  https://docbook.org/ns/docbook ([https](https://docbook.org/ns/docbook) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://www.reactive-streams.org/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* [ ] http://www.w3.org/1999/xlink with 1 occurrences migrated to:  
  https://www.w3.org/1999/xlink ([https](https://www.w3.org/1999/xlink) result 200).
* [ ] http://www.w3.org/2000/svg with 1 occurrences migrated to:  
  https://www.w3.org/2000/svg ([https](https://www.w3.org/2000/svg) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 4 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://www.spring.io with 16 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).