### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ public class Application {
 It's just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The `Function` is from `java.util` and `Flux` is a
-http://www.reactive-streams.org/[Reactive Streams] `Publisher` from
+https://www.reactive-streams.org/[Reactive Streams] `Publisher` from
 https://projectreactor.io/[Project Reactor]. The function can be
 accessed over HTTP or messaging.
 
@@ -155,7 +155,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -177,13 +177,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -239,7 +239,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -252,6 +252,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/intro.adoc
+++ b/docs/src/main/asciidoc/intro.adoc
@@ -31,7 +31,7 @@ public class Application {
 It's just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The `Function` is from `java.util` and `Flux` is a
-http://www.reactive-streams.org/[Reactive Streams] `Publisher` from
+https://www.reactive-streams.org/[Reactive Streams] `Publisher` from
 https://projectreactor.io/[Project Reactor]. The function can be
 accessed over HTTP or messaging.
 

--- a/spring-cloud-function-deployer/src/test/resources/app/META-INF/MANIFEST.MF
+++ b/spring-cloud-function-deployer/src/test/resources/app/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Main-Class: org.springframework.boot.loader.JarLauncher
 Start-Class: org.springframework.cloud.function.test.FunctionApp
 Created-By: Apache Maven 3.5.0
 Build-Jdk: 1.8.0_131
-Implementation-URL: http://projects.spring.io/spring-boot/function-sam
+Implementation-URL: https://projects.spring.io/spring-boot/function-sam
  ple/


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://projects.spring.io/spring-boot/function-sam (404) with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot/function-sam ([https](https://projects.spring.io/spring-boot/function-sam) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.reactive-streams.org/ with 2 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 11 occurrences