### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ public class Application {
 It's just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The `Function` is from `java.util` and `Flux` is a
-http://www.reactive-streams.org/[Reactive Streams] `Publisher` from
+https://www.reactive-streams.org/[Reactive Streams] `Publisher` from
 https://projectreactor.io/[Project Reactor]. The function can be
 accessed over HTTP or messaging.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.reactive-streams.org/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 8 occurrences
* http://localhost:9000/foos/ with 2 occurrences