### PR TITLE
Fix BeanFactoryFunctionCatalog initialization when a BeanFactoryPostProcessor

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
@@ -36,6 +36,7 @@ import com.google.gson.Gson;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -44,7 +45,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionRegistration;
 import org.springframework.cloud.function.context.FunctionRegistry;
@@ -54,7 +54,6 @@ import org.springframework.cloud.function.context.catalog.FunctionUnregistration
 import org.springframework.cloud.function.json.GsonMapper;
 import org.springframework.cloud.function.json.JacksonMapper;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
@@ -87,7 +86,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 
 	protected static class BeanFactoryFunctionCatalog
 			extends AbstractComposableFunctionRegistry
-			implements ApplicationListener<ApplicationReadyEvent>, BeanFactoryAware {
+		implements SmartInitializingSingleton, BeanFactoryAware {
 
 		private ApplicationEventPublisher applicationEventPublisher;
 
@@ -98,7 +97,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 		 * late as possible in the lifecycle.
 		 */
 		@Override
-		public void onApplicationEvent(ApplicationReadyEvent event) {
+		public void afterSingletonsInstantiated() {
 			Map<String, Supplier> supplierBeans = this.beanFactory
 				.getBeansOfType(Supplier.class);
 			Map<String, Function> functionBeans = this.beanFactory
@@ -228,7 +227,6 @@ public class ContextFunctionCatalogAutoConfiguration {
 			registrations.forEach(registration -> register(registration,
 					targets.get(registration.getTarget())));
 		}
-
 	}
 
 	private static class PreferGsonOrMissingJacksonCondition extends AnyNestedCondition {

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
@@ -35,7 +35,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -49,6 +48,7 @@ import org.springframework.cloud.function.compiler.CompiledFunctionFactory;
 import org.springframework.cloud.function.compiler.FunctionCompiler;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionRegistration;
+import org.springframework.cloud.function.context.FunctionRegistry;
 import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import org.springframework.cloud.function.inject.FooConfiguration;
 import org.springframework.cloud.function.scan.ScannedFunction;
@@ -58,11 +58,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.DescriptiveResource;
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StreamUtils;
@@ -73,6 +76,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  * @author Artem Bilan
  * @author Oleg Zhurakousky
+ * @author Anshul Mehra
  */
 public class ContextFunctionCatalogAutoConfigurationTests {
 
@@ -290,7 +294,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 						.isAssignableFrom(Mono.class);
 	}
 
-	@Test(expected = BeanCreationException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void monoToMonoNonVoidFunction() {
 		create(MonoToMonoNonVoidConfiguration.class);
 	}
@@ -589,6 +593,17 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 		assertThat(f.apply(Flux.just("foo")).blockFirst()).isEqualTo("FOO-bar");
 	}
 
+	@Test
+	public void autoConfiguredNonDefaultConstructorFunction() {
+		create(new Class[]{ComponentFunctionConfiguration.class, AppendFunction.class});
+		assertThat(this.context.getBean("appendFunction")).isInstanceOf(Function.class);
+		assertThat((Function<?, ?>) this.catalog.lookup(Function.class, "appendFunction"))
+			.isInstanceOf(Function.class);
+		Function<Flux<String>, Flux<String>> f = this.catalog.lookup(Function.class,
+			"appendFunction");
+		assertThat(f.apply(Flux.just("World")).blockFirst()).isEqualTo("Hello World");
+	}
+
 	private void create(Class<?> type, String... props) {
 		create(new Class<?>[] { type }, props);
 	}
@@ -641,6 +656,35 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 			return value -> this.list.add(value);
 		}
 
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	protected static class ComponentFunctionConfiguration {
+		@Bean
+		public String value() {
+			return "Hello ";
+		}
+
+		@Bean
+		public BeanFactoryPostProcessor someBeanFactoryPostProcessor(Environment environment,
+			@Nullable FunctionRegistry functionCatalog, @Nullable FunctionInspector inspector) {
+			return beanFactory -> { };
+		}
+	}
+
+	@Component("appendFunction")
+	public static class AppendFunction implements Function<String, String> {
+		private String value;
+
+		public AppendFunction(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String apply(String s) {
+			return this.value + s;
+		}
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
@@ -594,7 +594,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 	}
 
 	@Test
-	public void autoConfiguredNonDefaultConstructorFunction() {
+	public void functionCatalogDependentBeanFactoryPostProcessor() {
 		create(new Class[]{ComponentFunctionConfiguration.class, AppendFunction.class});
 		assertThat(this.context.getBean("appendFunction")).isInstanceOf(Function.class);
 		assertThat((Function<?, ?>) this.catalog.lookup(Function.class, "appendFunction"))


### PR DESCRIPTION
that depends on FunctionCatalog is present.

On application context refresh, BeanFactoryPostProcessors are
invoked before registering BeanPostProcessor(s).
If a BeanFactoryPostProcessor that depends on FunctionCatalog is present,
then when ContextFunctionCatalogAutoConfiguration tries to fetch
all functional beans (Function/Supplier/Consumer), the creation of beans
where no default constructor exists fails as
AutowiredAnnotationBeanPostProcessor hasn't been registered yet.

Initializing BeanFactoryFunctionCatalog on using SmartInitializingSingleton
delays the collection of functional beans to an even later point in
the lifecycle.

fixes #352