### PR TITLE
Add spring-cloud-function-kotlin to spring-cloud-function-dependencies.

### DIFF
--- a/spring-cloud-function-dependencies/pom.xml
+++ b/spring-cloud-function-dependencies/pom.xml
@@ -71,6 +71,11 @@
 				<artifactId>spring-cloud-function-adapter-openwhisk</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-kotlin</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<profiles>


### PR DESCRIPTION
This allows including the spring-cloud-function-kotlin dependency in a new spring boot project without needing to explicitly specify the version.