### PR TITLE
Fix context reinitialisation for azure functions

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/AzureSpringBootRequestHandlerTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/AzureSpringBootRequestHandlerTests.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import reactor.core.publisher.Flux;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.function.context.TargetContextHolder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -194,9 +195,9 @@ public class AzureSpringBootRequestHandlerTests {
 	protected static class AutoConfig {
 
 		@Bean
-		public Function<Foo, Bar> uppercase(ExecutionContext targetContext) {
+		public Function<Foo, Bar> uppercase(TargetContextHolder<ExecutionContext> targetContextHolder) {
 			return foo -> {
-				targetContext.getLogger().info("Invoking 'uppercase' on " + foo.getValue());
+				targetContextHolder.getTargetContext().getLogger().info("Invoking 'uppercase' on " + foo.getValue());
 				return new Bar(foo.getValue().toUpperCase());
 			};
 		}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/AbstractSpringFunctionAdapterInitializer.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/AbstractSpringFunctionAdapterInitializer.java
@@ -100,6 +100,7 @@ public abstract class AbstractSpringFunctionAdapterInitializer<C> implements Clo
 		if (!configurationClass.equals(contextStartClass)) {
 			context = null;
 		}
+		contextStartClass = configurationClass;
 	}
 
 	public AbstractSpringFunctionAdapterInitializer() {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/TargetContextHolder.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/TargetContextHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.context;
+
+/**
+ * Holds the targetContext passed by the function runtime.
+ *
+ * @param <C> the type of the target specific (native) context object.
+ *
+ * @author Arno De Witte
+ * @since 3.0.0
+ */
+public class TargetContextHolder<C> {
+
+	private final ThreadLocal<C> threadLocal = new InheritableThreadLocal();
+
+	public C getTargetContext() {
+		return this.threadLocal.get();
+	}
+
+	public void setTargetContext(C targetContext) {
+		this.threadLocal.set(targetContext);
+	}
+
+	public static <C> TargetContextHolder<C> of(C targetContext) {
+		TargetContextHolder<C> targetContextHolder = new TargetContextHolder<>();
+		targetContextHolder.setTargetContext(targetContext);
+		return targetContextHolder;
+	}
+}


### PR DESCRIPTION
I've created this pull request in regards to #425

This is a breaking change, as the ExecutionContext is no longer an injectable bean. This is impossible since the spring context is initialised once and then reused on consecutive function executions.

I've created a similar approach as with the SecurityContext in Spring Security and put the ExecutionContext in an ExecutionContextHolder, which is statically populated and holds the context threadlocal.

This pull request is missing an update to the documentation, as I want to have some feedback on the chosen solution.

