### PR TITLE
function-sample-azure cleanup

### DIFF
--- a/spring-cloud-function-samples/function-sample-azure/README.adoc
+++ b/spring-cloud-function-samples/function-sample-azure/README.adoc
@@ -4,7 +4,7 @@ You can run this sample locally, just like the other Spring Cloud Function sampl
 mvn spring-boot:run
 ----
 
-and `curl -H "Content-Type: application/json" localhost:8080/uppercase -d '{"value": "hello foobar"}'`.
+and `curl -H "Content-Type: application/json" localhost:7071/uppercase -d '{"value": "hello foobar"}'`.
 
 Given that our function takes POJO `Function<Foo, Bar> uppercase()` and it's input is JSON we need to
 provide the appropriate content-type (in this case `application/json`).

--- a/spring-cloud-function-samples/function-sample-azure/pom.xml
+++ b/spring-cloud-function-samples/function-sample-azure/pom.xml
@@ -19,14 +19,14 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<java.version>1.8</java.version>
 		<functionAppName>function-sample-azure</functionAppName>
 		<functionAppRegion>westus</functionAppRegion>
 		<functionResourceGroup>java-function-group</functionResourceGroup>
 		<stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>
 		<start-class>example.Config</start-class>
+		<azure.functions.maven.plugin.version>1.3.4</azure.functions.maven.plugin.version>
+		<azure.functions.java.library.version>1.3.0</azure.functions.java.library.version>
 		<wrapper.version>1.0.23.RELEASE</wrapper.version>
 	</properties>
 
@@ -58,6 +58,11 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+                <groupId>com.microsoft.azure.functions</groupId>
+                <artifactId>azure-functions-java-library</artifactId>
+                <version>${azure.functions.java.library.version}</version>
+            </dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -85,20 +90,9 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.0.2</version>
-				</plugin>
-				<plugin>
 					<groupId>com.microsoft.azure</groupId>
 					<artifactId>azure-functions-maven-plugin</artifactId>
-					<version>1.3.4</version>
-					<dependencies>
-						<dependency>
-							<groupId>javax.xml.bind</groupId>
-							<artifactId>jaxb-api</artifactId>
-							<version>2.3.1</version>
-						</dependency>
-					</dependencies>
+					<version>${azure.functions.maven.plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -127,6 +121,7 @@
 							<overWriteSnapshots>false</overWriteSnapshots>
 							<overWriteIfNewer>true</overWriteIfNewer>
 							<includeScope>runtime</includeScope>
+							<excludeArtifactIds>azure-functions-java-library</excludeArtifactIds>
 						</configuration>
 					</execution>
 				</executions>
@@ -139,14 +134,19 @@
 					<appName>${functionAppName}</appName>
 					<region>${functionAppRegion}</region>
 					<appSettings>
-						<property>
-							<name>FUNCTIONS_EXTENSION_VERSION</name>
-							<value>beta</value>
-						</property>
-						<property>
-							<name>MSDEPLOY_RENAME_LOCKED_FILES</name>
-							<value>1</value>
-						</property>
+						<!-- Run Azure Function from package file by default -->
+	                    <property>
+                           <name>WEBSITE_RUN_FROM_PACKAGE</name>
+                           <value>1</value>
+                       </property>
+                       <property>
+                           <name>FUNCTIONS_EXTENSION_VERSION</name>
+                           <value>~2</value>
+                       </property>
+                       <property>
+                           <name>FUNCTIONS_WORKER_RUNTIME</name>
+                           <value>java</value>
+                       </property>
 					</appSettings>
 				</configuration>
 				<executions>
@@ -170,7 +170,7 @@
 						<configuration>
 							<overwrite>true</overwrite>
 							<outputDirectory>
-								${project.build.directory}/azure-functions/${functionAppName}
+								${stagingDirectory}
 							</outputDirectory>
 							<resources>
 								<resource>


### PR DESCRIPTION
Cleaned up pom to use java.version instead of the compiler.source and compiler.target
Added version properties for azure-functions-java-library and azure-functions-maven-plugin
Updated the properties to be the latest recommended from Azure Functions
Used stagingDirectory in maven-resources-plugin
Updated README.adoc to say port 7071 instead of 8080