### PR TITLE
Fix a spell miss of AWS adapter intro documentation

### DIFF
--- a/docs/src/main/asciidoc/adapters/aws-intro.adoc
+++ b/docs/src/main/asciidoc/adapters/aws-intro.adoc
@@ -60,7 +60,7 @@ to use. The next section will explain you how you can accomplish just that.
 
 The adapter has a couple of generic request handlers that you can use. The most generic is (and the one we used in the Getting Started section)
 is `org.springframework.cloud.function.adapter.aws.FunctionInvoke` which is the implementation of AWS's `RequestStreamHandler`.
-User doesn't need to do anything other then specify it as 'handler' on AWS dashborad when deplioyimng function.
+User doesn't need to do anything other then specify it as 'handler' on AWS dashborad when deploying function.
 It will handle most of the case including Kinesis, streaming etc. .
 
 


### PR DESCRIPTION
Hi,

I guess there is a spell miss of the word "deplioyimng" which should be "deploying", in the AWS adapter introduction documentation.
So I am trying to fix it and please check am I correct or not.
Thanks!

Best Regards,
Reese