### PR TITLE
Add the GCP adapter to dependency management

### DIFF
--- a/spring-cloud-function-dependencies/pom.xml
+++ b/spring-cloud-function-dependencies/pom.xml
@@ -58,6 +58,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-adapter-gcp</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-function-adapter-openwhisk</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
Adds the `spring-cloud-function-adapter-gcp` artifact to dependency management.

cc/ @meltsufin @dmitry-s 