### PR TITLE
Add error code handling for the GCP Functions Adapter

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
@@ -98,6 +98,11 @@ public class FunctionInvoker extends AbstractSpringFunctionAdapterInitializer<Ht
 					httpResponse.appendHeader(header.getKey(), header.getValue().toString());
 				}
 			}
+			httpResponse.setStatusCode(200);
+		}
+		catch (Exception e) {
+			log.error("Error in HTTP Function Invoker", e);
+			httpResponse.setStatusCode(500, e.getMessage());
 		}
 		finally {
 			httpResponse.getWriter().close();

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
@@ -102,7 +102,7 @@ public class FunctionInvoker extends AbstractSpringFunctionAdapterInitializer<Ht
 		}
 		catch (Exception e) {
 			log.error("Error in HTTP Function Invoker", e);
-			httpResponse.setStatusCode(500, e.getMessage());
+			httpResponse.setStatusCode(500);
 		}
 		finally {
 			httpResponse.getWriter().close();

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerHttpTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerHttpTests.java
@@ -83,7 +83,7 @@ public class FunctionInvokerHttpTests {
 			when(response.getWriter()).thenReturn(new BufferedWriter(writer));
 
 			handler.service(request, response);
-			verify(response).setStatusCode(500, "The function is broken.");
+			verify(response).setStatusCode(500);
 		}
 	}
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/FunctionInvokerIntegrationTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/FunctionInvokerIntegrationTests.java
@@ -18,14 +18,20 @@ package org.springframework.cloud.function.adapter.gcp.integration;
 
 import java.io.IOException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.function.context.config.ContextFunctionCatalogAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.function.adapter.gcp.integration.LocalServerTestSupport.verify;
 
 /**
@@ -50,6 +56,40 @@ public class FunctionInvokerIntegrationTests {
 	@Test
 	public void testFooBar() {
 		verify(CloudFunctionMain.class, "foobar", new Foo("Hi"), new Bar("Hi"));
+	}
+
+	@Test
+	public void testErrorResponse() {
+		try (LocalServerTestSupport.ServerProcess serverProcess =
+						LocalServerTestSupport.startServer(ErrorFunction.class, "errorFunction")) {
+
+			TestRestTemplate testRestTemplate = new TestRestTemplate();
+
+			HttpHeaders headers = new HttpHeaders();
+			ResponseEntity<String> response = testRestTemplate.postForEntity(
+					"http://localhost:" + serverProcess.getPort(), new HttpEntity<>("test", headers),
+					String.class);
+
+			assertThat(response.getStatusCode().is5xxServerError()).isTrue();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * An example function which throws an error to test response code propagation.
+	 */
+	@Configuration
+	@Import({ ContextFunctionCatalogAutoConfiguration.class })
+	static class ErrorFunction {
+
+		@Bean
+		Supplier<String> errorFunction() {
+			return () -> {
+				throw new RuntimeException();
+			};
+		}
 	}
 
 	@Configuration

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
@@ -84,7 +84,7 @@ final public class LocalServerTestSupport {
 		}
 	}
 
-	private static ServerProcess startServer(Class<?> springApplicationMainClass, String function)
+	static ServerProcess startServer(Class<?> springApplicationMainClass, String function)
 			throws InterruptedException, IOException {
 		int port = nextPort.getAndIncrement();
 
@@ -147,7 +147,7 @@ final public class LocalServerTestSupport {
 		}
 	}
 
-	private static class ServerProcess implements AutoCloseable {
+	static class ServerProcess implements AutoCloseable {
 
 		private final Process process;
 

--- a/spring-cloud-function-samples/function-sample-gcp-http/src/main/java/com/example/CloudFunctionMain.java
+++ b/spring-cloud-function-samples/function-sample-gcp-http/src/main/java/com/example/CloudFunctionMain.java
@@ -31,8 +31,6 @@ public class CloudFunctionMain {
 
 	@Bean
 	public Function<String, String> function() {
-		return value -> {
-				throw new IllegalArgumentException("Function broken.");
-		};
+		return value -> value.toUpperCase();
 	}
 }

--- a/spring-cloud-function-samples/function-sample-gcp-http/src/main/java/com/example/CloudFunctionMain.java
+++ b/spring-cloud-function-samples/function-sample-gcp-http/src/main/java/com/example/CloudFunctionMain.java
@@ -31,6 +31,8 @@ public class CloudFunctionMain {
 
 	@Bean
 	public Function<String, String> function() {
-		return value -> value.toUpperCase();
+		return value -> {
+				throw new IllegalArgumentException("Function broken.");
+		};
 	}
 }


### PR DESCRIPTION
Adds error code handling for the GCP Functions Adapter.

If an exception is thrown, it will set the error code of the response to 500.

Fixes #539 

cc/ @meltsufin @dmitry-s @saturnism 