### PR TITLE
Fix error propagation for GCP adapter

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
@@ -85,22 +85,17 @@ public class FunctionInvoker extends AbstractSpringFunctionAdapterInitializer<Ht
 	 */
 	@Override
 	public void service(HttpRequest httpRequest, HttpResponse httpResponse) throws Exception {
-		try {
-			Function<Message<BufferedReader>, Message<byte[]>> function = lookupFunction();
+		Function<Message<BufferedReader>, Message<byte[]>> function = lookupFunction();
 
-			Message<BufferedReader> message = getInputType() == Void.class ? null
-					: MessageBuilder.withPayload(httpRequest.getReader()).copyHeaders(httpRequest.getHeaders()).build();
-			Message<byte[]> result = function.apply(message);
+		Message<BufferedReader> message = getInputType() == Void.class ? null
+				: MessageBuilder.withPayload(httpRequest.getReader()).copyHeaders(httpRequest.getHeaders()).build();
+		Message<byte[]> result = function.apply(message);
 
-			if (result != null) {
-				httpResponse.getWriter().write(new String(result.getPayload(), StandardCharsets.UTF_8));
-				for (Entry<String, Object> header : result.getHeaders().entrySet()) {
-					httpResponse.appendHeader(header.getKey(), header.getValue().toString());
-				}
+		if (result != null) {
+			httpResponse.getWriter().write(new String(result.getPayload(), StandardCharsets.UTF_8));
+			for (Entry<String, Object> header : result.getHeaders().entrySet()) {
+				httpResponse.appendHeader(header.getKey(), header.getValue().toString());
 			}
-		}
-		finally {
-			httpResponse.getWriter().close();
 		}
 	}
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerHttpTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerHttpTests.java
@@ -83,9 +83,14 @@ public class FunctionInvokerHttpTests {
 
 			HttpResponse response = Mockito.mock(HttpResponse.class);
 			StringWriter writer = new StringWriter();
-			when(response.getWriter()).thenReturn(new BufferedWriter(writer));
 
+			BufferedWriter bufferedWriter = new BufferedWriter(writer);
+			when(response.getWriter()).thenReturn(bufferedWriter);
 			handler.service(request, response);
+
+			// Closing the writer is done by the Framework/caller.
+			bufferedWriter.close();
+
 			if (expectedOutput != null) {
 				assertThat(writer.toString()).isEqualTo(gson.toJson(expectedOutput));
 			}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/FunctionInvokerIntegrationTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/FunctionInvokerIntegrationTests.java
@@ -18,14 +18,20 @@ package org.springframework.cloud.function.adapter.gcp.integration;
 
 import java.io.IOException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.function.context.config.ContextFunctionCatalogAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.function.adapter.gcp.integration.LocalServerTestSupport.verify;
 
 /**
@@ -50,6 +56,40 @@ public class FunctionInvokerIntegrationTests {
 	@Test
 	public void testFooBar() {
 		verify(CloudFunctionMain.class, "foobar", new Foo("Hi"), new Bar("Hi"));
+	}
+
+	@Test
+	public void testErrorResponse() {
+		try (LocalServerTestSupport.ServerProcess serverProcess =
+						LocalServerTestSupport.startServer(ErrorFunction.class, "errorFunction")) {
+
+			TestRestTemplate testRestTemplate = new TestRestTemplate();
+
+			HttpHeaders headers = new HttpHeaders();
+			ResponseEntity<String> response = testRestTemplate.postForEntity(
+					"http://localhost:" + serverProcess.getPort(), new HttpEntity<>("test", headers),
+					String.class);
+
+			assertThat(response.getStatusCode().is5xxServerError()).isTrue();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * An example function which throws an error to test response code propagation.
+	 */
+	@Configuration
+	@Import({ ContextFunctionCatalogAutoConfiguration.class })
+	static class ErrorFunction {
+
+		@Bean
+		Supplier<String> errorFunction() {
+			return () -> {
+				throw new RuntimeException();
+			};
+		}
 	}
 
 	@Configuration

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
@@ -84,7 +84,7 @@ final public class LocalServerTestSupport {
 		}
 	}
 
-	private static ServerProcess startServer(Class<?> springApplicationMainClass, String function)
+	static ServerProcess startServer(Class<?> springApplicationMainClass, String function)
 			throws InterruptedException, IOException {
 		int port = nextPort.getAndIncrement();
 
@@ -147,7 +147,7 @@ final public class LocalServerTestSupport {
 		}
 	}
 
-	private static class ServerProcess implements AutoCloseable {
+	static class ServerProcess implements AutoCloseable {
 
 		private final Process process;
 


### PR DESCRIPTION
This fixes the error propagation for the GCP adapter. Now when exceptions are thrown from the function, the http response should be `500`.

The only change done here is to remove the call to `httpResponse.getWriter().close()`; the removal of this call allows the outer-level caller to set the `500` response code correctly when exception is thrown.

Please see `FunctionInvokerIntegrationTests.testErrorResponse()` for verification.

Fixes #539.

cc/ @meltsufin @dmitry-s @saturnism 