### PR TITLE
Improve FunctionRegistry Logger

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -85,7 +85,7 @@ import org.springframework.util.StringUtils;
  */
 public class SimpleFunctionRegistry implements FunctionRegistry, FunctionInspector {
 
-	Log logger = LogFactory.getLog(this.getClass());
+	protected Log logger = LogFactory.getLog(this.getClass());
 
 	/**
 	 * Identifies MessageConversionExceptions that happen when input can't be converted.

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -85,7 +85,7 @@ import org.springframework.util.StringUtils;
  */
 public class SimpleFunctionRegistry implements FunctionRegistry, FunctionInspector {
 
-	Log logger = LogFactory.getLog(SimpleFunctionRegistry.class);
+	Log logger = LogFactory.getLog(this.getClass());
 
 	/**
 	 * Identifies MessageConversionExceptions that happen when input can't be converted.


### PR DESCRIPTION
The `protected` change should be obvious.

The other change, replacing the static class reference with the runtime call `getClass()`, is necessary  to have better logs in cases when a subclassed instance is emitting log messages (e.g. `BeanFactoryAwareFunctionRegistry`).