### PR TITLE
add plugin repositories to fix gcp-background sample

### DIFF
--- a/spring-cloud-function-samples/function-sample-gcp-background/pom.xml
+++ b/spring-cloud-function-samples/function-sample-gcp-background/pom.xml
@@ -90,4 +90,33 @@
 			</snapshots>
 		</repository>
 	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/libs-release-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 </project>

--- a/spring-cloud-function-samples/pom.xml
+++ b/spring-cloud-function-samples/pom.xml
@@ -23,7 +23,7 @@
 		<module>function-sample-azure</module>
 		<!--><module>function-sample-spring-integration</module>-->
 		<module>function-sample-gcp-http</module>
-<!-- 		<module>function-sample-gcp-background</module> -->
+ 		<module>function-sample-gcp-background</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
This PR fixes spring-cloud-function-samples module and enables it.

cc/ @olegz @meltsufin @dzou 