### PR TITLE
Implement lookupStrict

### DIFF
--- a/spring-cloud-function-context/pom.xml
+++ b/spring-cloud-function-context/pom.xml
@@ -14,6 +14,9 @@
 		<artifactId>spring-cloud-function-parent</artifactId>
 		<version>3.1.0-SNAPSHOT</version>
 	</parent>
+	<properties>
+		<kafka.version>2.5.0</kafka.version>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -63,6 +66,18 @@
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-streams</artifactId>
+			<version>${kafka.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionCatalog.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionCatalog.java
@@ -23,10 +23,14 @@ import java.util.function.Supplier;
 
 import javax.activation.MimeType;
 
+import org.springframework.cloud.function.context.catalog.exception.FunctionDefinitionDoesNotExistException;
+import org.springframework.cloud.function.context.catalog.exception.UnsupportedFunctionException;
+
 
 /**
  * @author Dave Syer
  * @author Oleg Zhurakousky
+ * @author David Turanski
  */
 public interface FunctionCatalog {
 
@@ -71,6 +75,19 @@ public interface FunctionCatalog {
 	default <T> T lookup(String functionDefinition) {
 		return this.lookup(null, functionDefinition);
 	}
+
+	/**
+	 * Will look up the instance of the functional interface by name only.
+	 *
+	 * @param                    <T> instance type
+	 * @param functionDefinition the definition of the functional interface. Must
+	 *                           not be null;
+	 * @return instance of the functional interface registered with this catalog
+	 * @throws FunctionDefinitionDoesNotExistException if no function with the given definition exists
+	 * @throws UnsupportedFunctionException if the function exists but is an unsupported type
+	 */
+	<T> T lookupStrict(String functionDefinition);
+
 
 	/**
 	 * Will look up the instance of the functional interface by name and type which

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/InMemoryFunctionCatalog.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/InMemoryFunctionCatalog.java
@@ -50,4 +50,9 @@ public class InMemoryFunctionCatalog extends AbstractComposableFunctionRegistry 
 		}
 		return functionType;
 	}
+
+	@Override
+	public <T> T lookupStrict(String functionDefinition) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/exception/FunctionDefinitionDoesNotExistException.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/exception/FunctionDefinitionDoesNotExistException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.context.catalog.exception;
+
+/**
+ * @author David Turanski
+ */
+public class FunctionDefinitionDoesNotExistException extends RuntimeException {
+	public FunctionDefinitionDoesNotExistException(String message) {
+		super(message);
+	}
+}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/exception/UnsupportedFunctionException.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/exception/UnsupportedFunctionException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.context.catalog.exception;
+
+/**
+ * @author David Turanski
+ */
+public class UnsupportedFunctionException extends RuntimeException {
+
+	public UnsupportedFunctionException(String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
Proposed fix for the kafka-streams error resulting from chage to throw exception on invalid function definitions in SCSt `FunctionConfiguration`.  This adds a new `lookupStrict` method to the catalog that will throw a typed exception to distinguish between `unsupported` and `does not exist definition`.   New method for b/w compatibility.  This can be used in `FunctionConfiguration` to pass if the function exists but is unsupported.  Not ideal since KStreams binder uses the same property `spring.cloud.function.definition`  to bind functions. IMO kstreams binder should use a different property, e.g. something like `spring.cloud.stream.binder.kafka.streams.function....`  but that would be a breaking change.  This PR is a bit of a hack. But I feel strongly that setting the function definition to a non existent function should throw an exception.