### PR TITLE
Keep headers of functions returning multiple messages

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
@@ -92,7 +92,8 @@ final public class LocalServerTestSupport {
 		File javaHome = new File(System.getProperty("java.home"));
 		assertThat(javaHome.exists()).isTrue();
 		File javaBin = new File(javaHome, "bin");
-		File javaCommand = new File(javaBin, "java");
+		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+		File javaCommand = new File(javaBin, isWindows ? "java.exe": "java");
 		assertThat(javaCommand.exists()).isTrue();
 		String myClassPath = System.getProperty("java.class.path");
 		assertThat(myClassPath).isNotNull();


### PR DESCRIPTION
I a function returns a collection of messages.
All headers was drop and replaced by just content/type.

This disables the functionality of set message destination via header.