### PR TITLE
Version 3.1.2-SNAPSHOT is not yet avialable

### DIFF
--- a/spring-cloud-function-samples/function-sample-aws-custom-bean/pom.xml
+++ b/spring-cloud-function-samples/function-sample-aws-custom-bean/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<wrapper.version>1.0.22.RELEASE</wrapper.version>
-		<spring-cloud-function.version>3.1.2-SNAPSHOT</spring-cloud-function.version>
+		<spring-cloud-function.version>3.1.1</spring-cloud-function.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
I've looked for the dep onto https://repo.spring.io/release/org/springframework/cloud/spring-cloud-function-dependencies/

To run the mvn package I needed to change version into 3.1.1, is this fair to make a pull request ? (just trying to help)