### PR TITLE
AWS: Change Default environment values

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoop.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoop.java
@@ -122,7 +122,7 @@ public class CustomRuntimeEventLoop {
 	}
 
 	private static FunctionInvocationWrapper locateFunction(FunctionCatalog functionCatalog, MediaType contentType) {
-		String handlerName = System.getenv("_HANDLER");
+		String handlerName = System.getenv("DEFAULT_HANDLER");
 		FunctionInvocationWrapper function = functionCatalog.lookup(handlerName, contentType.toString());
 		if (function == null) {
 			handlerName = System.getenv("spring.cloud.function.definition");


### PR DESCRIPTION
I've faced the "The key must start with a letter and can only contain letters, numbers, and underscores." issue in the AWS lambda. So both _HANDLER and spring.cloud.function.definition were not enabled to be added as environment variables. Let me know your thoughts.