### PR TITLE
Array reification error with KStream[] in Kotlin

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionRegistration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionRegistration.java
@@ -125,6 +125,9 @@ public class FunctionRegistration<T> implements BeanNameAware {
 	public FunctionRegistration<T> type(FunctionType type) {
 
 		Type t = FunctionTypeUtils.discoverFunctionTypeFromClass(this.target.getClass());
+		if (t == null) { // only valid for Kafka Stream KStream[] return type.
+			return null;
+		}
 		FunctionType discoveredFunctionType = FunctionType.of(t);
 		Class<?> inputType = TypeResolver.resolveRawClass(discoveredFunctionType.getInputType(), null);
 		Class<?> outputType = TypeResolver.resolveRawClass(discoveredFunctionType.getOutputType(), null);

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistry.java
@@ -141,8 +141,10 @@ public class BeanFactoryAwareFunctionRegistry extends SimpleFunctionRegistry imp
 						if (functionRegistration == null) {
 							functionRegistration = new FunctionRegistration(functionCandidate, functionName).type(functionType);
 						}
-
-						this.register(functionRegistration);
+						// Certain Kafka Streams functions such as KStream[] return types could be null (esp when using Kotlin).
+						if (functionRegistration != null) {
+							this.register(functionRegistration);
+						}
 					}
 					else {
 						if (logger.isDebugEnabled()) {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -149,6 +149,13 @@ public final class FunctionTypeUtils {
 		Assert.isTrue(isFunctional(functionalClass), "Type must be one of Supplier, Function or Consumer");
 
 		if (Function.class.isAssignableFrom(functionalClass)) {
+			for (Type superInterface : functionalClass.getGenericInterfaces()) {
+				if (superInterface != null && !superInterface.equals(Object.class)) {
+					if (superInterface.toString().contains("KStream") && ResolvableType.forType(superInterface).getGeneric(1).isArray()) {
+						return null;
+					}
+				}
+			}
 			return TypeResolver.reify(Function.class, (Class<Function<?, ?>>) functionalClass);
 		}
 		else if (Consumer.class.isAssignableFrom(functionalClass)) {


### PR DESCRIPTION
Exclude Kafka Streams functions with KStream[] return type as this
causes some array reification errors in Kotlin.

See this issue for more details: https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1044

Resolves https://github.com/spring-cloud/spring-cloud-function/issues/669