### PR TITLE
Default to gson JSON mapper for GCP Adapter if not specified

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
@@ -66,6 +66,7 @@ public class FunctionInvoker extends AbstractSpringFunctionAdapterInitializer<Ht
 		if (System.getenv().containsKey("spring.cloud.function.definition")) {
 			this.functionName = System.getenv("spring.cloud.function.definition");
 		}
+		System.setProperty("spring.http.converters.preferred-json-mapper", "gson");
 		Thread.currentThread() // TODO: remove after upgrading to 1.0.0-alpha-2-rc5
 				.setContextClassLoader(FunctionInvoker.class.getClassLoader());
 		initialize(null);

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
@@ -66,7 +66,12 @@ public class FunctionInvoker extends AbstractSpringFunctionAdapterInitializer<Ht
 		if (System.getenv().containsKey("spring.cloud.function.definition")) {
 			this.functionName = System.getenv("spring.cloud.function.definition");
 		}
-		System.setProperty("spring.http.converters.preferred-json-mapper", "gson");
+
+		// Default to GSON if implementation not specified.
+		if (!System.getenv().containsKey("spring.http.converters.preferred-json-mapper")) {
+			System.setProperty("spring.http.converters.preferred-json-mapper", "gson");
+		}
+
 		Thread.currentThread() // TODO: remove after upgrading to 1.0.0-alpha-2-rc5
 				.setContextClassLoader(FunctionInvoker.class.getClassLoader());
 		initialize(null);

--- a/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
+++ b/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
@@ -74,7 +74,7 @@
 					<dependency>
 						<groupId>org.springframework.cloud</groupId>
 						<artifactId>spring-cloud-function-adapter-gcp</artifactId>
-						<version>3.1.0-SNAPSHOT</version>
+						<version>3.1.3-SNAPSHOT</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
+++ b/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-function-adapter-gcp</artifactId>
-			<version>3.1.2-SNAPSHOT</version>
+			<version>3.1.3-SNAPSHOT</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
This PR makes it so that the adapter defaults to using the GSON adapter if it is not specified.

I saw originally that the [JSON mapper preference was removed initially to accommodate Jackson](https://github.com/spring-cloud/spring-cloud-function/issues/570).

However, if the user forgets to set `spring.http.converters.preferred-json-mapper` altogether, the adapter will not work. This can be verified by:

* Checkout this branch
* Remove the `if (..) { System.setProperty("spring.http.converters.preferred-json-mapper", "gson") }` and re-install adapter.
* `cd spring-cloud-function-samples/function-sample-gcp-http`
* Run `mvn function:run` to start the function.
* Run `curl localhost:8080/testFunction -d 'test'` to send a curl request to it.

If the json mapper preference is omitted, you will get an error like: 

```
WARNING: Failed to execute org.springframework.cloud.function.adapter.gcp.GcfJarLauncher
java.lang.ClassCastException: class org.eclipse.jetty.server.Request$1 cannot be cast to class [B (org.eclipse.jetty.server.Request$1 is in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @4c58255; [B is in module java.base of loader 'bootstrap')
	at org.springframework.messaging.converter.StringMessageConverter.convertFromInternal(StringMessageConverter.java:60)
	at org.springframework.messaging.converter.AbstractMessageConverter.fromMessage(AbstractMessageConverter.java:185)
	at org.springframework.messaging.converter.AbstractMessageConverter.fromMessage(AbstractMessageConverter.java:176)
	at org.springframework.cloud.function.context.config.SmartCompositeMessageConverter.fromMessage(SmartCompositeMessageConverter.java:48)
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.convertInputMessageIfNecessary(SimpleFunctionRegistry.java:1109)
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.convertInputIfNecessary(SimpleFunctionRegistry.java:903)
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.doApply(SimpleFunctionRegistry.java:603)
```

I think this PR might be a good compromise to default to `gson` when `spring.http.converters.preferred-json-mapper` is not specified by the user. What do you think @olegz, @meltsufin ?