### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ cache:
   directories:
     - $HOME/.m2
 install: true
-before_script: travis_wait 45 ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
+before_script: ./mvnw install -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
 script: ./mvnw install -q -nsu -Dmaven.test.redirectTestOutputToFile=true
 dist: trusty


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
