### PR TITLE
FIX: Update azure-function-maven-plugin version to 1.12.0

### DIFF
--- a/spring-cloud-function-samples/function-sample-azure/pom.xml
+++ b/spring-cloud-function-samples/function-sample-azure/pom.xml
@@ -25,7 +25,7 @@
 		<functionResourceGroup>java-function-group</functionResourceGroup>
 		<stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>
 		<start-class>example.Config</start-class>
-		<azure.functions.maven.plugin.version>1.3.4</azure.functions.maven.plugin.version>
+		<azure.functions.maven.plugin.version>1.12.0</azure.functions.maven.plugin.version>
 		<azure.functions.java.library.version>1.3.0</azure.functions.java.library.version>
 		<wrapper.version>1.0.23.RELEASE</wrapper.version>
 	</properties>


### PR DESCRIPTION
**Description**

Running the function-sample-azure example with the command _mvn azure-functions:run_ as described in sample's README file, the command line stucks like on the screenshot below

![2021-08-21 13_26_14-Window](https://user-images.githubusercontent.com/34707374/130320468-206b4789-b194-4384-84a3-f173498ea02f.png)

Azure Functions Core Tools version is 3.0.3477

![2021-08-21 13_27_16-Window](https://user-images.githubusercontent.com/34707374/130320501-82c23fc1-2b29-4104-aa80-4a61caad4749.png)

**Solution**

Following the issue https://github.com/Azure/azure-functions-core-tools/issues/2619 and changing the version of azure-functions-maven-plugin to 1.12.0 the issue was resolved