### PR TITLE
Performance improvements

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/MessageHandlingHelper.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/MessageHandlingHelper.java
@@ -354,7 +354,7 @@ public class MessageHandlingHelper<T extends GeneratedMessageV3> implements Smar
 			functionDefinition = (String) headers.get(FunctionProperties.FUNCTION_DEFINITION);
 		}
 		FunctionInvocationWrapper function = this.functionCatalog.lookup(functionDefinition, "application/json");
-		Assert.notNull(function, "Failed to lookup function " + funcProperties.getDefinition());
+		Assert.notNull(function, () -> "Failed to lookup function " + funcProperties.getDefinition());
 		return function;
 	}
 }

--- a/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/config/FunctionProxyApplicationListener.java
+++ b/spring-cloud-function-compiler/src/main/java/org/springframework/cloud/function/compiler/config/FunctionProxyApplicationListener.java
@@ -92,7 +92,7 @@ public class FunctionProxyApplicationListener
 			String type = (properties.get("type") != null) ? properties.get("type")
 					: "function";
 			String lambda = properties.get("lambda");
-			Assert.notNull(lambda, String.format(
+			Assert.notNull(lambda, () -> String.format(
 					"The 'lambda' property is required for compiling Function: %s",
 					name));
 			String inputType = properties.get("inputType");

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -1040,7 +1040,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry, FunctionInspect
 			if (this.isWrapConvertedInputInMessage(convertedInput)) {
 				convertedInput = MessageBuilder.withPayload(convertedInput).build();
 			}
-			Assert.notNull(convertedInput, "Failed to convert input: " + input + " to " + type);
+			Assert.notNull(convertedInput, () -> "Failed to convert input: " + input + " to " + type);
 			return convertedInput;
 		}
 


### PR DESCRIPTION
Avoid generating strings and implicit toString() calls that will be garbage most of the time.

I didt some performance tests and analysed the gc allocation rate.
Here i found some low hanging fruits that will reduce the gc throughput and improve the performance.

You can see here unnecessary created objects.
![image](https://user-images.githubusercontent.com/512850/140484312-32547a9d-d869-40f9-b594-190d2aa59d72.png)

If you have a look at:
`Assert.notNull(convertedInput, "Failed to convert input: " + input + " to " + type);`

If input is a complex object, the toString() method of this object will be called all the time.
Even if convertedInput is not null.

Specially at this line of code we could go one step more and change it to:
```
if (convertedInput == null) {
  throw new IllegalArgumentException("Failed to convert input: " + input + " to " + type);
}
```
what is exactly the same as `Assert.notNull` does but also saving the creation of the lambda.
This might be a good idea, because this method will be called for each message send with spring-cloud-stream.
