### PR TITLE
Update gcp adapter version to the latest snapshot

### DIFF
--- a/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
+++ b/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
@@ -19,11 +19,15 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
+	<properties>
+		<spring-cloud-function.version>3.2.1-SNAPSHOT</spring-cloud-function.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-function-adapter-gcp</artifactId>
-			<version>3.1.3-SNAPSHOT</version>
+			<version>${spring-cloud-function.version}</version>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -38,8 +42,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -74,7 +78,7 @@
 					<dependency>
 						<groupId>org.springframework.cloud</groupId>
 						<artifactId>spring-cloud-function-adapter-gcp</artifactId>
-						<version>3.1.3-SNAPSHOT</version>
+						<version>${spring-cloud-function.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
I've used a Maven property to set the versions in both, runtime and plugin dependencies. Will this property get updated during the normal SCF release process?

While there, I've also updated JUnit4 dependency to JUnit5 -- the imports were updated but the dependency was still old, so the test was not running.

Fixes #774