### PR TITLE
Remove skipConversion in FunctionAroundWrapper

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionAroundWrapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionAroundWrapper.java
@@ -38,9 +38,8 @@ public abstract class FunctionAroundWrapper implements BiFunction<Object, Functi
 
 	@Override
 	public final Object apply(Object input, FunctionInvocationWrapper targetFunction) {
-		String functionalTracingEnabledStr = System.getProperty("spring.sleuth.function.enabled");
-		boolean functionalTracingEnabled =
-			!StringUtils.hasText(functionalTracingEnabledStr) || Boolean.parseBoolean(functionalTracingEnabledStr);
+		String functionalTracingEnabledStr = System.getProperty("spring.sleuth.function.enabled", "true");
+		boolean functionalTracingEnabled = Boolean.parseBoolean(functionalTracingEnabledStr);
 		if (functionalTracingEnabled) {
 			return this.doApply(input, targetFunction);
 		}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionAroundWrapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionAroundWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,11 @@ import org.springframework.util.StringUtils;
  * If registered as bean it will be autowired into {@link FunctionInvocationWrapper}.
  * Keep in mind that it only affects imperative invocations where input is {@link Message}
  *
- * NOTE: This API is experimental and and could change without notice. It is
+ * NOTE: This API is experimental and could change without notice. It is
  * intended for internal use only (e.g., spring-cloud-sleuth)
  *
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 3.1
  */
 public abstract class FunctionAroundWrapper implements BiFunction<Object, FunctionInvocationWrapper, Object> {
@@ -38,17 +39,10 @@ public abstract class FunctionAroundWrapper implements BiFunction<Object, Functi
 	@Override
 	public final Object apply(Object input, FunctionInvocationWrapper targetFunction) {
 		String functionalTracingEnabledStr = System.getProperty("spring.sleuth.function.enabled");
-		boolean functionalTracingEnabled = StringUtils.hasText(functionalTracingEnabledStr)
-				? Boolean.parseBoolean(functionalTracingEnabledStr) : true;
+		boolean functionalTracingEnabled =
+			!StringUtils.hasText(functionalTracingEnabledStr) || Boolean.parseBoolean(functionalTracingEnabledStr);
 		if (functionalTracingEnabled) {
-			boolean isSkipOutputConversion = targetFunction.isSkipOutputConversion();
-			targetFunction.setSkipOutputConversion(true);
-			try {
-				return this.doApply(input, targetFunction);
-			}
-			finally {
-				targetFunction.setSkipOutputConversion(isSkipOutputConversion);
-			}
+			return this.doApply(input, targetFunction);
 		}
 		else {
 			return targetFunction.apply(input);
@@ -56,4 +50,5 @@ public abstract class FunctionAroundWrapper implements BiFunction<Object, Functi
 	}
 
 	protected abstract Object doApply(Object input, FunctionInvocationWrapper targetFunction);
+
 }


### PR DESCRIPTION
Currently, the `FunctionAroundWrapper` set `targetFunction.setSkipOutputConversion(true);`
which is not what expected by the `TraceFunctionAroundWrapper`.
This one has a logic based on the `Message` as an output from the target function
and its headers to correlate tracing headers.

* Remove the `setSkipOutputConversion(true)` from the `FunctionAroundWrapper`
to satisfy `TraceFunctionAroundWrapper` expectation - we cannot enforce
all the end-user function to always return a `Message<?>` for us.
* Some other refactoring in the `FunctionAroundWrapper` for cleaner code

**Cherry-pick to `3.2.x`**