### PR TITLE
Remove FunctionType from docs and AWS sample

### DIFF
--- a/docs/src/main/asciidoc/adapters/aws.adoc
+++ b/docs/src/main/asciidoc/adapters/aws.adoc
@@ -31,7 +31,7 @@ public class FuncApplication implements ApplicationContextInitializer<GenericApp
 	public void initialize(GenericApplicationContext context) {
 		context.registerBean("function", FunctionRegistration.class,
 			() -> new FunctionRegistration<Function<Foo, Bar>>(function())
-				.type(FunctionType.from(Foo.class).to(Bar.class).getType()));
+                .type(FunctionTypeUtils.functionType(Foo.class, Bar.class)));
 	}
 
 }

--- a/docs/src/main/asciidoc/functional.adoc
+++ b/docs/src/main/asciidoc/functional.adoc
@@ -40,7 +40,7 @@ public class DemoApplication implements ApplicationContextInitializer<GenericApp
   public void initialize(GenericApplicationContext context) {
     context.registerBean("demo", FunctionRegistration.class,
         () -> new FunctionRegistration<>(uppercase())
-            .type(FunctionType.from(String.class).to(String.class)));
+            .type(FunctionTypeUtils.functionType(String.class, String.class)));
   }
 
 }

--- a/spring-cloud-function-samples/function-sample-functional-aws-routing/src/main/java/example/FunctionConfiguration.java
+++ b/spring-cloud-function-samples/function-sample-functional-aws-routing/src/main/java/example/FunctionConfiguration.java
@@ -5,12 +5,9 @@ import java.util.function.Function;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.function.context.FunctionRegistration;
-import org.springframework.cloud.function.context.FunctionType;
 import org.springframework.cloud.function.context.MessageRoutingCallback;
-import org.springframework.cloud.function.context.MessageRoutingCallback.FunctionRoutingResult;
-import org.springframework.cloud.function.json.JsonMapper;
+import org.springframework.cloud.function.context.catalog.FunctionTypeUtils;
 import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.messaging.Message;
 
@@ -51,9 +48,9 @@ public class FunctionConfiguration implements ApplicationContextInitializer<Gene
 				() -> new RoutingCallback());
 		applicationContext.registerBean("uppercase", FunctionRegistration.class,
                 () -> new FunctionRegistration<>(uppercase()).type(
-                        FunctionType.from(String.class).to(String.class)));
+					FunctionTypeUtils.functionType(String.class, String.class)));
 		applicationContext.registerBean("reverse", FunctionRegistration.class,
                 () -> new FunctionRegistration<>(reverse()).type(
-                        FunctionType.from(String.class).to(String.class)));
+                        FunctionTypeUtils.functionType(String.class, String.class)));
 	}
 }


### PR DESCRIPTION
Updates docs and remove use of FunctionType in AWS sample (follow up to https://github.com/spring-cloud/spring-cloud-function/commit/7a2b2b2fc7e786afe2364295c3f7d3cc6221d6f6)