### PR TITLE
SimpleFunctionRegistry: Fixed: compose of supplier...consumer pipelin…

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -80,6 +80,7 @@ import org.springframework.util.StringUtils;
  * such as type conversion, composition, POJO etc.
  *
  * @author Oleg Zhurakousky
+ * @author Roman Samarev
  *
  */
 public class SimpleFunctionRegistry implements FunctionRegistry, FunctionInspector {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -625,9 +625,9 @@ public class SimpleFunctionRegistry implements FunctionRegistry, FunctionInspect
 
 			Type composedFunctionType;
 			if (afterWrapper.outputType == null) {
-				composedFunctionType = ResolvableType.forClassWithGenerics(Consumer.class, this.inputType == null
-						? null
-						: ResolvableType.forType(this.inputType)).getType();
+				composedFunctionType = (this.inputType == null) ?
+					ResolvableType.forClassWithGenerics(Supplier.class, ResolvableType.forType(Object.class)).getType() :
+					ResolvableType.forClassWithGenerics(Consumer.class, ResolvableType.forType(this.inputType)).getType();
 			}
 			else if (this.inputType == null && afterWrapper.outputType != null) {
 				ResolvableType composedOutputType;

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
@@ -23,10 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
@@ -527,6 +529,30 @@ public class SimpleFunctionRegistryTests {
 		assertThat(FunctionTypeUtils.isMono(function.getOutputType()));
 	}
 
+	@Test
+	public void testFunctionCompositionWithReactiveSupplierAndConsumer() {
+		SimpleFunctionRegistry catalog = new SimpleFunctionRegistry(this.conversionService, this.messageConverter,
+			new JacksonMapper(new ObjectMapper()));
+
+		Object reactiveFunc = reactiveFluxSupplier();
+		FunctionRegistration functionRegistration = new FunctionRegistration(reactiveFunc, "reactiveFluxSupplier")
+			.type(ResolvableType.forClassWithGenerics(
+				Supplier.class, ResolvableType.forClassWithGenerics(Flux.class, String.class)).getType());
+		catalog.register(functionRegistration);
+
+		reactiveFunc = reactiveFluxConsumer();
+		functionRegistration = new FunctionRegistration(reactiveFunc, "reactiveFluxConsumer")
+			.type(ResolvableType.forClassWithGenerics(
+				Consumer.class, ResolvableType.forClassWithGenerics(Flux.class, String.class)).getType());
+		catalog.register(functionRegistration);
+
+		FunctionInvocationWrapper lookedUpFunction = catalog
+			.lookup("reactiveFluxSupplier|reactiveFluxConsumer");
+
+		assertThat(lookedUpFunction).isNotNull();
+		lookedUpFunction.apply(null);
+		assertThat(consumerDowncounter.get()).isZero();
+	}
 
 	public Function<String, String> uppercase() {
 		return v -> v.toUpperCase();
@@ -549,6 +575,18 @@ public class SimpleFunctionRegistryTests {
 		return flux -> flux.subscribe(v -> {
 			System.out.println(v);
 		});
+	}
+
+	private final AtomicInteger consumerDowncounter = new AtomicInteger(10);
+
+	public Supplier<Flux<String>> reactiveFluxSupplier() {
+		return () -> Flux.fromStream(
+			IntStream.range(0, consumerDowncounter.get()).boxed().map(i -> Integer.toString(i))
+		);
+	}
+
+	public Consumer<Flux<String>> reactiveFluxConsumer() {
+		return flux -> flux.subscribe(v -> consumerDowncounter.decrementAndGet());
 	}
 
 	private FunctionCatalog configureCatalog(Class<?>... configClass) {


### PR DESCRIPTION
Fix of the case when we have a complete pipeline `supplier-processor-consumer` without input and output.

That case is important for unit testing of cloud-function-based application with complex connections. E.g. we have a database. But data for saving are sent through a message queue with spring cloud bindings. At the same time we need to be sure data were processed and saved properly in a test without real external connections. In that case, we need to declare a unit test with a composite function like `"spring.cloud.function.definition = dataSupplier|dataProcessor|dataSaver;"`.

```
Test:
  data = do_something;
  emit_dataSupplier(data); // -> write to DB with `dataSaver`
  do_something_other();

  Awaitility.await().until(() -> !read_from_db().isEmpty());
  validation_data = read_from_db();

  assertThat(data).isEqual(f(validation_data));
```


Before this patch, the composite function doesn't create `_integrationflow.router`. The function with both input and output nulls is considered as a `Consumer` with `Object` input type. And, further `isSupplier()` gives `false` for any check. The only case when that is working properly - last component name in the pipeline is a literally `Function` with some non null output type. Now, the compose with supplier-consumer generates a `Supplier` type with `Object` output and might be activated explicitly with `apply(null)` or with `sink.tryEmitNext(data)`.

Definitely, the case with a pipeline without input and output is completely wrong in terms of Supplier, Function, Consumer terminology. But without that, no way to test this kind of pipelines in real applications.