### PR TITLE
Update code examples in docs

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -42,6 +42,12 @@
 					<plugin>
 						<groupId>org.asciidoctor</groupId>
 						<artifactId>asciidoctor-maven-plugin</artifactId>
+						<configuration>
+							<attributes>
+								<project-version>${project.version}</project-version>
+								<spring-boot-version>${spring-boot.version}</spring-boot-version>
+							</attributes>
+						</configuration>
 					</plugin>
 					
 					<plugin>

--- a/docs/src/main/asciidoc/functional.adoc
+++ b/docs/src/main/asciidoc/functional.adoc
@@ -265,19 +265,19 @@ like the `@Autowired` `TestRestTemplate`, are standard Spring Boot features.
 
 And to help with correct dependencies here is the excerpt from POM
 
-[source, xml]
+[source, xml, subs=attributes+]
 ----
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.2.RELEASE</version>
+        <version>{spring-boot-version}</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     . . . .
     <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-function-web</artifactId>
-        <version>3.0.1.BUILD-SNAPSHOT</version>
+        <version>{project-version}</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -292,12 +292,6 @@ And to help with correct dependencies here is the excerpt from POM
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-test</artifactId>
         <scope>test</scope>
-        <exclusions>
-            <exclusion>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-            </exclusion>
-        </exclusions>
     </dependency>
 ----
 
@@ -305,7 +299,6 @@ Or you could write a test for a non-HTTP app using just the `FunctionCatalog`. F
 
 [source, java]
 ----
-@RunWith(SpringRunner.class)
 @FunctionalSpringBootTest
 public class FunctionalTests {
 
@@ -313,7 +306,7 @@ public class FunctionalTests {
 	private FunctionCatalog catalog;
 
 	@Test
-	public void words() throws Exception {
+	public void words() {
 		Function<String, String> function = catalog.lookup(Function.class,
 				"uppercase");
 		assertThat(function.apply("hello")).isEqualTo("HELLO");


### PR DESCRIPTION
### Reflect current versions and APIs being used
Version numbers and some API use was outdated in the code examples

### Use dynamic version numbers based on maven properties
This will prevent the version numbers from getting stale in the code examples (they will bump when the project bumps)

#### THIS
<img width="466" alt="Screen Shot 2022-02-13 at 11 03 21 AM" src="https://user-images.githubusercontent.com/28907971/153766046-93a801b6-4df3-46a7-95c0-1a22cbbbef5c.png">

#### BECOMES THIS
<img width="539" alt="Screen Shot 2022-02-13 at 11 02 00 AM" src="https://user-images.githubusercontent.com/28907971/153766054-accfeafd-ab85-44e1-b956-e64a4e51e42d.png">

