### PR TITLE
Reduce use of SocketUtils in tests

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/pom.xml
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/pom.xml
@@ -55,6 +55,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/test/java/org/springframework/cloud/function/grpc/GrpcInteractionTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/test/java/org/springframework/cloud/function/grpc/GrpcInteractionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.MimeTypeUtils;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -46,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  *
  * @author Oleg Zhurakousky
- *
+ * @author Chris Bono
  */
 @Disabled
 public class GrpcInteractionTests {
@@ -62,13 +61,14 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testRequestReply() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testRequestReply() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=uppercase",
-						"--spring.cloud.function.grpc.port=" + port)) {
+						"--spring.cloud.function.grpc.port=0")) {
+
+			int port = patientlyGetPort(context);
 
 			Message<byte[]> message = MessageBuilder.withPayload("\"hello gRPC\"".getBytes())
 					.setHeader("foo", "bar")
@@ -82,13 +82,14 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testRequestReplyWithMonoReturn() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testRequestReplyWithMonoReturn() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
-						"--spring.cloud.function.definition=uppercaseMonoReturn",
-						"--spring.cloud.function.grpc.port=" + port)) {
+						"--spring.cloud.function.definition=uppercaseMonoReturn", 
+						"--spring.cloud.function.grpc.port=0")) {
+
+			int port = patientlyGetPort(context);
 
 			Message<byte[]> message = MessageBuilder.withPayload("\"hello gRPC\"".getBytes())
 					.setHeader("foo", "bar")
@@ -102,14 +103,15 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testRequestReplyWithFluxReturn() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testRequestReplyWithFluxReturn() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=uppercaseFluxReturn",
-						"--spring.cloud.function.grpc.port=" + port)) {
+						"--spring.cloud.function.grpc.port=0")) {
 
+			int port = patientlyGetPort(context);
+			
 			Message<byte[]> message = MessageBuilder.withPayload("\"hello gRPC\"".getBytes())
 					.setHeader("foo", "bar")
 					.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN)
@@ -125,13 +127,14 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testRequstReplyFunctionDefinitionInMessage() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testRequstReplyFunctionDefinitionInMessage() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
-						"--spring.cloud.function.grpc.port=" + port)) {
+						"--spring.cloud.function.grpc.port=0")) {
 
+			int port = patientlyGetPort(context);
+			
 			Message<byte[]> message = MessageBuilder.withPayload("\"hello gRPC\"".getBytes())
 					.setHeader("foo", "bar")
 					.setHeader("spring.cloud.function.definition", "reverse")
@@ -144,14 +147,15 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testBidirectionalStreamWithImperativeFunction() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testBidirectionalStreamWithImperativeFunction() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=uppercase",
-						"--spring.cloud.function.grpc.port=" + port)) {
+						"--spring.cloud.function.grpc.port=0")) {
 
+			int port = patientlyGetPort(context);
+			
 			List<Message<byte[]>> messages = new ArrayList<>();
 			messages.add(MessageBuilder.withPayload("\"Ricky\"".getBytes()).setHeader("foo", "bar")
 					.build());
@@ -172,15 +176,15 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testBidirectionalStreamWithReactiveFunction() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testBidirectionalStreamWithReactiveFunction() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=uppercaseReactive",
-						"--spring.cloud.function.grpc.port="
-								+ port)) {
+						"--spring.cloud.function.grpc.port=0")) {
 
+			int port = patientlyGetPort(context);
+			
 			List<Message<byte[]>> messages = new ArrayList<>();
 			messages.add(MessageBuilder.withPayload("\"Ricky\"".getBytes()).setHeader("foo", "bar")
 					.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN)
@@ -204,14 +208,14 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testClientStreaming() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testClientStreaming() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=streamInStringOut",
-						"--spring.cloud.function.grpc.port="
-								+ port)) {
+						"--spring.cloud.function.grpc.port=0")) {
+
+			int port = patientlyGetPort(context);
 
 			List<Message<byte[]>> messages = new ArrayList<>();
 			messages.add(MessageBuilder.withPayload("\"Ricky\"".getBytes()).setHeader("foo", "bar")
@@ -229,14 +233,14 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testServerStreaming() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testServerStreaming() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=stringInStreamOut",
-						"--spring.cloud.function.grpc.port="
-								+ port)) {
+						"--spring.cloud.function.grpc.port=0")) {
+
+			int port = patientlyGetPort(context);
 
 			Message<byte[]> message = MessageBuilder.withPayload("\"Ricky\"".getBytes()).setHeader("foo", "bar").build();
 
@@ -251,14 +255,14 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testBiStreamStreamInStringOutFailure() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testBiStreamStreamInStringOutFailure() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=streamInStringOut",
-						"--spring.cloud.function.grpc.port="
-								+ port)) {
+						"--spring.cloud.function.grpc.port=0")) {
+
+			int port = patientlyGetPort(context);
 
 			List<Message<byte[]>> messages = new ArrayList<>();
 			messages.add(MessageBuilder.withPayload("\"Ricky\"".getBytes()).setHeader("foo", "bar")
@@ -276,14 +280,14 @@ public class GrpcInteractionTests {
 	}
 
 	@Test
-	public void testBiStreamStringInStreamOutFailure() {
-		int port = SocketUtils.findAvailableTcpPort();
+	public void testBiStreamStringInStreamOutFailure() throws Exception {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				SampleConfiguration.class).web(WebApplicationType.NONE).run(
 						"--spring.jmx.enabled=false",
 						"--spring.cloud.function.definition=stringInStreamOut",
-						"--spring.cloud.function.grpc.port="
-								+ port)) {
+						"--spring.cloud.function.grpc.port=0")) {
+
+			int port = patientlyGetPort(context);
 
 			List<Message<byte[]>> messages = new ArrayList<>();
 			messages.add(MessageBuilder.withPayload("\"Ricky\"".getBytes()).setHeader("foo", "bar")
@@ -298,6 +302,17 @@ public class GrpcInteractionTests {
 
 			assertThat(clientResponseObserver.collectList().block(Duration.ofSeconds(2))).isEmpty();
 		}
+	}
+
+	private int patientlyGetPort(ConfigurableApplicationContext context) throws InterruptedException {
+		Thread.sleep(500);
+		String port = context.getEnvironment().getProperty("local.grpc.server.port");
+		if (port == null) {
+			Thread.sleep(500);
+			port = context.getEnvironment().getProperty("local.grpc.server.port");
+			assertThat(port).as("Unable to get 'local.grpc.server.port' - server may not have started up").isNotNull();
+		}
+		return Integer.valueOf(port);
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/MessageRoutingCallbackRSocketTests.java
+++ b/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/MessageRoutingCallbackRSocketTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,28 +33,28 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.rsocket.RSocketRequester;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.MimeTypeUtils;
-import org.springframework.util.SocketUtils;
 
 /**
  *
  * @author Oleg Zhurakousky
- *
+ * @author Chris Bono
  */
 public class MessageRoutingCallbackRSocketTests {
 
 	@Test
 	public void testRoutingWithRoutingCallback() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(RoutingCallbackFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 							"--spring.cloud.function.expected-content-type=text/plain",
-							"--spring.rsocket.server.port=" + port);
+							"--spring.rsocket.server.port=0");
 		) {
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
+
+			int port = applicationContext.getEnvironment().getProperty("local.rsocket.server.port", Integer.class);
 
 			// imperative
 			rsocketRequesterBuilder.tcp("localhost", port)

--- a/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/MessagingTests.java
+++ b/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/MessagingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,27 +34,27 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.rsocket.RSocketRequester;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
  * @author Oleg Zhurakousky
- *
+ * @author Chris Bono
  */
 public class MessagingTests {
 
 	@Test
 	public void testPojoToStringViaMessage() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -76,14 +76,15 @@ public class MessagingTests {
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void testPojoToStringViaMessageMap() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -107,14 +108,15 @@ public class MessagingTests {
 
 	@Test
 	public void testPojoToStringViaMessageExpectMessage() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -136,14 +138,15 @@ public class MessagingTests {
 
 	@Test
 	public void testPojoMessageToPojoViaMessage() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -167,14 +170,15 @@ public class MessagingTests {
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void testPojoMessageToPojoViaMap() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -200,14 +204,15 @@ public class MessagingTests {
 
 	@Test
 	public void testPojoMessageToPojoViaMessageExpectMessage() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -229,14 +234,15 @@ public class MessagingTests {
 
 	@Test
 	public void testPojoMessageToPojoViaMessageExpectMessageRawPayload() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -258,14 +264,15 @@ public class MessagingTests {
 
 	@Test
 	public void testPojoMessageToPojoViaMessageExpectMessageStringPayload() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -287,14 +294,15 @@ public class MessagingTests {
 
 	@Test
 	public void testPojoToMessageMap() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(MessagingConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 			Person p = new Person();
@@ -311,7 +319,9 @@ public class MessagingTests {
 		}
 	}
 
-
+	private int getLocalRsocketPort(ConfigurableApplicationContext context) {
+		return context.getEnvironment().getProperty("local.rsocket.server.port", Integer.class);
+	}
 
 	@EnableAutoConfiguration
 	@Configuration

--- a/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RSocketAutoConfigurationRoutingTests.java
+++ b/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RSocketAutoConfigurationRoutingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,19 +37,18 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.DestinationPatternsMessageCondition;
 import org.springframework.messaging.rsocket.RSocketRequester;
 import org.springframework.util.MimeTypeUtils;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Chris Bono
  * @since 3.1
  */
 public class RSocketAutoConfigurationRoutingTests {
 	@Test
 	public void testRoutingWithRoute() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
@@ -57,8 +56,10 @@ public class RSocketAutoConfigurationRoutingTests {
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 							"--spring.cloud.function.routing-expression=headers.func_name",
 							"--spring.cloud.function.expected-content-type=text/plain",
-							"--spring.rsocket.server.port=" + port);
+							"--spring.rsocket.server.port=0");
 		) {
+			int port = applicationContext.getEnvironment().getProperty("local.rsocket.server.port", Integer.class);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -97,7 +98,6 @@ public class RSocketAutoConfigurationRoutingTests {
 
 	@Test
 	public void testRoutingWithDefinition() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
@@ -106,8 +106,10 @@ public class RSocketAutoConfigurationRoutingTests {
 							"--spring.cloud.function.definition=uppercase",
 							"--spring.cloud.function.routing-expression=headers.func_name",
 							"--spring.cloud.function.expected-content-type=text/plain",
-							"--spring.rsocket.server.port=" + port);
+							"--spring.rsocket.server.port=0");
 		) {
+			int port = applicationContext.getEnvironment().getProperty("local.rsocket.server.port", Integer.class);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -146,7 +148,6 @@ public class RSocketAutoConfigurationRoutingTests {
 
 	@Test
 	public void testRoutingWithDefinitionMessageFunction() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
@@ -155,8 +156,9 @@ public class RSocketAutoConfigurationRoutingTests {
 							"--spring.cloud.function.definition=uppercase",
 							"--spring.cloud.function.routing-expression=headers.func_name",
 							"--spring.cloud.function.expected-content-type=text/plain",
-							"--spring.rsocket.server.port=" + port);
+							"--spring.rsocket.server.port=0");
 		) {
+			int port = applicationContext.getEnvironment().getProperty("local.rsocket.server.port", Integer.class);
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 

--- a/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RSocketAutoConfigurationTests.java
+++ b/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RSocketAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,27 +41,28 @@ import org.springframework.messaging.rsocket.RSocketRequester;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Chris Bono
  * @since 3.1
  */
 public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testNonExistingFunctionInRoute() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -77,14 +78,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testNonExistingFunctionInRouteSingleFunctionInCatalog() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SingleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -103,15 +105,16 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testImperativeFunctionAsRequestReplyWithDefinition() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 						"--spring.cloud.function.definition=uppercase",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -129,15 +132,16 @@ public class RSocketAutoConfigurationTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testWithCborContentType() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 						"--spring.cloud.function.definition=uppercase",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -158,7 +162,6 @@ public class RSocketAutoConfigurationTests {
 	@Test
 	@Disabled
 	public void testImperativeFunctionAsRequestReplyWithDefinitionExplicitExpectedOutputCt() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
@@ -166,8 +169,10 @@ public class RSocketAutoConfigurationTests {
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 						"--spring.cloud.function.definition=uppercase",
 						"--spring.cloud.function.expected-content-type=application/json",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -184,14 +189,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testImperativeFunctionAsRequestReply() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -208,15 +214,16 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testWithRouteAndDefinition() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 							"--spring.cloud.function.definition=echo",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -233,14 +240,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testImperativeFunctionAsRequestReplyWithComposition() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -257,14 +265,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testSupplierAsRequestReply() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -281,14 +290,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testImperativeFunctionAsRequestStream() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -305,14 +315,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testImperativeFunctionAsRequestChannel() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -330,14 +341,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testReactiveFunctionAsRequestReply() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -354,14 +366,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testReactiveFunctionAsRequestStream() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -394,14 +407,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testReactiveFunctionAsRequestChannel() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -418,16 +432,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testRequestReplyFunctionWithDistributedComposition() {
-		int portA = SocketUtils.findAvailableTcpPort();
-		int portB = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 						"--spring.cloud.function.definition=uppercase|concat",
-						"--spring.rsocket.server.port=" + portA);
+						"--spring.rsocket.server.port=0");
 		) {
+			int portA = getLocalRsocketPort(applicationContext);
 
 			try (
 				ConfigurableApplicationContext applicationContext2 =
@@ -435,8 +448,10 @@ public class RSocketAutoConfigurationTests {
 						.web(WebApplicationType.NONE)
 						.run("--logging.level.org.springframework.cloud.function=DEBUG",
 							"--spring.cloud.function.definition=reverse>localhost:" + portA + "|wrap",
-							"--spring.rsocket.server.port=" + portB);
+							"--spring.rsocket.server.port=0");
 			) {
+
+				int portB = getLocalRsocketPort(applicationContext2);
 
 				RSocketRequester.Builder rsocketRequesterBuilder =
 					applicationContext2.getBean(RSocketRequester.Builder.class);
@@ -497,17 +512,17 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testFireAndForgetConsumer() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
 
 			SampleFunctionConfiguration config = applicationContext.getBean(SampleFunctionConfiguration.class);
 
+			int port = getLocalRsocketPort(applicationContext);
 
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
@@ -560,15 +575,16 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testRoutingWithRoutingFunction() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
 							"--spring.cloud.function.routing-expression=headers.function_definition",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -586,14 +602,15 @@ public class RSocketAutoConfigurationTests {
 
 	@Test
 	public void testByteArrayInOut() {
-		int port = SocketUtils.findAvailableTcpPort();
 		try (
 			ConfigurableApplicationContext applicationContext =
 				new SpringApplicationBuilder(SampleFunctionConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.rsocket.server.port=" + port);
+						"--spring.rsocket.server.port=0");
 		) {
+			int port = getLocalRsocketPort(applicationContext);
+
 			RSocketRequester.Builder rsocketRequesterBuilder =
 				applicationContext.getBean(RSocketRequester.Builder.class);
 
@@ -613,6 +630,10 @@ public class RSocketAutoConfigurationTests {
 
 			assertThat(resultBytes).isEqualTo("HELLO".getBytes());
 		}
+	}
+
+	private int getLocalRsocketPort(ConfigurableApplicationContext context) {
+		return context.getEnvironment().getProperty("local.rsocket.server.port", Integer.class);
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RoutingBrokerTests.java
+++ b/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RoutingBrokerTests.java
@@ -102,7 +102,7 @@ public class RoutingBrokerTests {
 				"--logging.level.io.rsocket.broker=TRACE",
 				"--spring.cloud.function.rsocket.enabled=false",
 				"--io.rsocket.broker.client.enabled=false",
-				"--io.rsocket.broker.enaFunctionEndpointInitializerbled=true",
+				"--io.rsocket.broker.enabled=true",
 				"--io.rsocket.broker.uri=tcp://localhost:" + brokerProxyPort,
 				"--io.rsocket.broker.cluster.uri=tcp://localhost:" + brokerClusterPort);
 

--- a/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RoutingBrokerTests.java
+++ b/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/RoutingBrokerTests.java
@@ -33,7 +33,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.rsocket.RSocketRequester;
-import org.springframework.util.SocketUtils;
 
 
 /**
@@ -96,14 +95,14 @@ public class RoutingBrokerTests {
 	}
 
 	private void setup(boolean routingWithProperty) {
-		int brokerProxyPort = SocketUtils.findAvailableTcpPort();
-		int brokerClusterPort = SocketUtils.findAvailableTcpPort();
+		int brokerProxyPort = TestSocketUtils.findAvailableTcpPort();
+		int brokerClusterPort = TestSocketUtils.findAvailableTcpPort();
 		// start broker
 		brokerContext = new SpringApplicationBuilder(SimpleConfiguration.class).web(WebApplicationType.NONE).run(
 				"--logging.level.io.rsocket.broker=TRACE",
 				"--spring.cloud.function.rsocket.enabled=false",
 				"--io.rsocket.broker.client.enabled=false",
-				"--io.rsocket.broker.enabled=true",
+				"--io.rsocket.broker.enaFunctionEndpointInitializerbled=true",
 				"--io.rsocket.broker.uri=tcp://localhost:" + brokerProxyPort,
 				"--io.rsocket.broker.cluster.uri=tcp://localhost:" + brokerClusterPort);
 

--- a/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/TestSocketUtils.java
+++ b/spring-cloud-function-rsocket/src/test/java/org/springframework/cloud/function/rsocket/TestSocketUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.rsocket;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.Random;
+
+import javax.net.ServerSocketFactory;
+
+/**
+ * Simple test utility to find a random available TCP port.
+ * <p>Inspired by the now removed {@code org.springframework.util.SocketUtils} and is only used in a testing capacity.
+ *
+ * @author Chris Bono
+ * @deprecated will soon be removed or consolidated - do not use further
+ */
+@Deprecated
+public final class TestSocketUtils {
+
+	private static final Random random = new Random(System.nanoTime());
+
+	private TestSocketUtils() {
+	}
+
+	/**
+	 * Find an available TCP port randomly selected from the range {@code 1024-65535}.
+	 * @return an available TCP port number
+	 * @throws IllegalStateException if no available port could be found
+	 */
+	public static int findAvailableTcpPort() {
+		int minPort = 1024;
+		int maxPort = 65535;
+		int portRange = maxPort - minPort;
+		int candidatePort;
+		int searchCounter = 0;
+		do {
+			if (searchCounter > portRange) {
+				throw new IllegalStateException(String.format(
+					"Could not find an available TCP port after %d attempts", searchCounter));
+			}
+			candidatePort = minPort + random.nextInt(portRange + 1);
+			searchCounter++;
+		}
+		while (!isPortAvailable(candidatePort));
+
+		return candidatePort;
+	}
+
+	private static boolean isPortAvailable(int port) {
+		try {
+			ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(
+				port, 1, InetAddress.getByName("localhost"));
+			serverSocket.close();
+			return true;
+		}
+		catch (Exception ex) {
+			return false;
+		}
+	}
+}

--- a/spring-cloud-function-web/pom.xml
+++ b/spring-cloud-function-web/pom.xml
@@ -41,6 +41,11 @@
 			<artifactId>spring-cloud-function-context</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>1.2</version>
@@ -57,9 +62,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/FunctionalExporterTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/FunctionalExporterTests.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.function.context.FunctionRegistration;
 import org.springframework.cloud.function.context.catalog.FunctionTypeUtils;
 import org.springframework.cloud.function.context.test.FunctionalSpringBootTest;
 import org.springframework.cloud.function.test.FunctionalExporterTests.ApplicationConfiguration;
+import org.springframework.cloud.function.web.TestSocketUtils;
 import org.springframework.cloud.function.web.source.SupplierExporter;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -41,7 +42,6 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.ReflectionUtils;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -70,7 +70,7 @@ public class FunctionalExporterTests {
 	@BeforeAll
 	public static void init() throws Exception {
 		headers.clear();
-		String port = "" + SocketUtils.findAvailableTcpPort();
+		String port = "" + TestSocketUtils.findAvailableTcpPort();
 		System.setProperty("server.port", port);
 		System.setProperty("my.port", port);
 		context = SpringApplication.run(RestPojoConfiguration.class,

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/TestSocketUtils.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/TestSocketUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.web;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.Random;
+
+import javax.net.ServerSocketFactory;
+
+/**
+ * Simple test utility to find a random available TCP port.
+ * <p>Inspired by the now removed {@code org.springframework.util.SocketUtils} and is only used in a testing capacity.
+ *
+ * @author Chris Bono
+ * @deprecated will soon be removed or consolidated - do not use further
+ */
+@Deprecated
+public final class TestSocketUtils {
+
+	private static final Random random = new Random(System.nanoTime());
+
+	private TestSocketUtils() {
+	}
+
+	/**
+	 * Find an available TCP port randomly selected from the range {@code 1024-65535}.
+	 * @return an available TCP port number
+	 * @throws IllegalStateException if no available port could be found
+	 */
+	public static int findAvailableTcpPort() {
+		int minPort = 1024;
+		int maxPort = 65535;
+		int portRange = maxPort - minPort;
+		int candidatePort;
+		int searchCounter = 0;
+		do {
+			if (searchCounter > portRange) {
+				throw new IllegalStateException(String.format(
+					"Could not find an available TCP port after %d attempts", searchCounter));
+			}
+			candidatePort = minPort + random.nextInt(portRange + 1);
+			searchCounter++;
+		}
+		while (!isPortAvailable(candidatePort));
+
+		return candidatePort;
+	}
+
+	private static boolean isPortAvailable(int port) {
+		try {
+			ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(
+				port, 1, InetAddress.getByName("localhost"));
+			serverSocket.close();
+			return true;
+		}
+		catch (Exception ex) {
+			return false;
+		}
+	}
+}

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerMVCTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerMVCTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,43 +19,30 @@ package org.springframework.cloud.function.web.function;
 import java.net.URI;
 import java.util.function.Function;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Chris Bono
  * @since 2.1
- *
  */
 public class FunctionEndpointInitializerMVCTests {
 
-	@BeforeEach
-	public void init() throws Exception {
-		String port = "" + SocketUtils.findAvailableTcpPort();
-		System.setProperty("server.port", port);
-	}
-
-	@AfterEach
-	public void close() throws Exception {
-		System.clearProperty("server.port");
-	}
-
 	@Test
 	public void testSingleFunctionMapping() throws Exception {
-		SpringApplication.run(ApplicationConfiguration.class);
+		ConfigurableApplicationContext context = SpringApplication.run(ApplicationConfiguration.class, "--server.port=0");
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
+		String port = context.getEnvironment().getProperty("local.server.port");
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/uppercase"), "stressed", String.class);
 		assertThat(response.getBody()).isEqualTo("STRESSED");
@@ -65,9 +52,9 @@ public class FunctionEndpointInitializerMVCTests {
 
 	@Test
 	public void testCompositionFunctionMapping() throws Exception {
-		SpringApplication.run(ApplicationConfiguration.class);
+		ConfigurableApplicationContext context = SpringApplication.run(ApplicationConfiguration.class, "--server.port=0");
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
+		String port = context.getEnvironment().getProperty("local.server.port");
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/uppercase,lowercase,reverse"), "stressed", String.class);
 		assertThat(response.getBody()).isEqualTo("desserts");

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringBootConfiguration;
@@ -31,39 +29,26 @@ import org.springframework.cloud.function.context.FunctionRegistration;
 import org.springframework.cloud.function.context.FunctionalSpringApplication;
 import org.springframework.cloud.function.context.catalog.FunctionTypeUtils;
 import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
 *
 * @author Oleg Zhurakousky
+* @author Chris Bono
 * @since 2.1
-*
 */
 public class FunctionEndpointInitializerTests {
 
-	@BeforeEach
-	public void init() throws Exception {
-		String port = "" + SocketUtils.findAvailableTcpPort();
-		System.setProperty("server.port", port);
-	}
-
-	@AfterEach
-	public void close() throws Exception {
-		System.clearProperty("server.port");
-	}
-
 	@Test
 	public void testNonExistingFunction() throws Exception {
-		FunctionalSpringApplication.run(ApplicationConfiguration.class);
+		int port = startServerAndWaitForPort(ApplicationConfiguration.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
-		Thread.sleep(200);
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/foo"), "stressed", String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -71,10 +56,8 @@ public class FunctionEndpointInitializerTests {
 
 	@Test
 	public void testConsumerMapping() throws Exception {
-		FunctionalSpringApplication.run(ConsumerConfiguration.class);
+		int port = startServerAndWaitForPort(ConsumerConfiguration.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
-		Thread.sleep(200);
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/uppercase"), "stressed", String.class);
 		assertThat(response.getBody()).isNull();
@@ -83,10 +66,8 @@ public class FunctionEndpointInitializerTests {
 
 	@Test
 	public void testSingleFunctionMapping() throws Exception {
-		FunctionalSpringApplication.run(ApplicationConfiguration.class);
+		int port = startServerAndWaitForPort(ApplicationConfiguration.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
-		Thread.sleep(200);
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/uppercase"), "stressed", String.class);
 		assertThat(response.getBody()).isEqualTo("STRESSED");
@@ -96,10 +77,8 @@ public class FunctionEndpointInitializerTests {
 
 	@Test
 	public void testCompositionFunctionMapping() throws Exception {
-		FunctionalSpringApplication.run(ApplicationConfiguration.class);
+		int port = startServerAndWaitForPort(ApplicationConfiguration.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
-		Thread.sleep(200);
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/uppercase,lowercase,reverse"), "stressed", String.class);
 		assertThat(response.getBody()).isEqualTo("desserts");
@@ -107,10 +86,8 @@ public class FunctionEndpointInitializerTests {
 
 	@Test
 	public void testGetWithtFunction() throws Exception {
-		FunctionalSpringApplication.run(ApplicationConfiguration.class);
+		int port = startServerAndWaitForPort(ApplicationConfiguration.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
-		Thread.sleep(2000);
 		ResponseEntity<String> response = testRestTemplate
 				.getForEntity(new URI("http://localhost:" + port + "/reverse/stressed"), String.class);
 		System.out.println();
@@ -119,13 +96,23 @@ public class FunctionEndpointInitializerTests {
 
 	@Test
 	public void testGetWithtSupplier() throws Exception {
-		FunctionalSpringApplication.run(ApplicationConfiguration.class);
+		int port = startServerAndWaitForPort(ApplicationConfiguration.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
-		Thread.sleep(200);
 		ResponseEntity<String> response = testRestTemplate
 				.getForEntity(new URI("http://localhost:" + port + "/supplier"), String.class);
 		assertThat(response.getBody()).isEqualTo("Jim Lahey");
+	}
+
+	private int startServerAndWaitForPort(Class<?> primaryAppConfig) throws InterruptedException {
+		ConfigurableApplicationContext context = FunctionalSpringApplication.run(primaryAppConfig, "--server.port=0");
+		Thread.sleep(500);
+		String port = context.getEnvironment().getProperty("local.server.port");
+		if (port == null) {
+			Thread.sleep(500);
+			port = context.getEnvironment().getProperty("local.server.port");
+			assertThat(port).as("Unable to get 'local.server.port' - server may not have started up").isNotNull();
+		}
+		return Integer.valueOf(port);
 	}
 
 	@SpringBootConfiguration

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/UserSubmittedTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/UserSubmittedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,44 +19,31 @@ package org.springframework.cloud.function.web.function;
 import java.net.URI;
 import java.util.function.Function;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.SocketUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Chris Bono
  * @since 2.1
- *
  */
 public class UserSubmittedTests {
 
-	@BeforeEach
-	public void init() throws Exception {
-		String port = "" + SocketUtils.findAvailableTcpPort();
-		System.setProperty("server.port", port);
-	}
-
-	@AfterEach
-	public void close() throws Exception {
-		System.clearProperty("server.port");
-	}
-
 	@Test
 	public void testIssue274() throws Exception {
-		SpringApplication.run(Issue274Configuration.class);
+		ConfigurableApplicationContext context = SpringApplication.run(Issue274Configuration.class, "--server.port=0");
+		int port = context.getEnvironment().getProperty("local.server.port", Integer.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
 		Thread.sleep(200);
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/echo"), "", String.class);
@@ -66,9 +53,9 @@ public class UserSubmittedTests {
 
 	@Test
 	public void testIssue274WithData() throws Exception {
-		SpringApplication.run(Issue274Configuration.class);
+		ConfigurableApplicationContext context = SpringApplication.run(Issue274Configuration.class, "--server.port=0");
+		int port = context.getEnvironment().getProperty("local.server.port", Integer.class);
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
-		String port = System.getProperty("server.port");
 		Thread.sleep(200);
 		ResponseEntity<String> response = testRestTemplate
 				.postForEntity(new URI("http://localhost:" + port + "/echo"), "hello", String.class);

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/MultipartFileTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/MultipartFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.function.Function;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;
@@ -37,34 +35,22 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.SocketUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 /**
  *
  * @author Oleg Zhurakousky
- *
+ * @author Chris Bono
  */
 public class MultipartFileTests {
 
-	@BeforeEach
-	public void init() throws Exception {
-		String port = "" + SocketUtils.findAvailableTcpPort();
-		System.setProperty("server.port", port);
-	}
-
-	@AfterEach
-	public void close() throws Exception {
-		System.clearProperty("server.port");
-	}
-
 	@Test
 	public void testMultipartFileUpload() throws Exception {
-		ApplicationContext context = SpringApplication.run(TestConfiguration.class);
+		ApplicationContext context = SpringApplication.run(TestConfiguration.class, "--server.port=0");
+		String port = context.getEnvironment().getProperty("local.server.port");
 		JsonMapper mapper = context.getBean(JsonMapper.class);
 		TestRestTemplate template = new TestRestTemplate();
-		String port = System.getProperty("server.port");
 
 		LinkedMultiValueMap<String, Object> map = new LinkedMultiValueMap<>();
 		map.add("file", new ClassPathResource("META-INF/spring.factories"));
@@ -81,10 +67,10 @@ public class MultipartFileTests {
 
 	@Test
 	public void testMultipartFilesUpload() throws Exception {
-		ApplicationContext context = SpringApplication.run(TestConfiguration.class);
+		ApplicationContext context = SpringApplication.run(TestConfiguration.class, "--server.port=0");
+		String port = context.getEnvironment().getProperty("local.server.port");
 		JsonMapper mapper = context.getBean(JsonMapper.class);
 		TestRestTemplate template = new TestRestTemplate();
-		String port = System.getProperty("server.port");
 
 		LinkedMultiValueMap<String, Object> map = new LinkedMultiValueMap<>();
 		map.add("fileA", new ClassPathResource("META-INF/spring.factories"));

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationIntegrationTests.java
@@ -34,11 +34,11 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.function.web.TestSocketUtils;
 import org.springframework.cloud.function.web.source.FunctionAutoConfigurationIntegrationTests.ApplicationConfiguration;
 import org.springframework.cloud.function.web.source.FunctionAutoConfigurationIntegrationTests.RestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.SocketUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -68,7 +68,7 @@ public class FunctionAutoConfigurationIntegrationTests {
 
 	@BeforeAll
 	public static void init() {
-		System.setProperty("server.port", "" + SocketUtils.findAvailableTcpPort());
+		System.setProperty("server.port", "" + TestSocketUtils.findAvailableTcpPort());
 	}
 
 	@AfterAll

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationWithRetriesIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationWithRetriesIntegrationTests.java
@@ -32,11 +32,11 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.function.web.TestSocketUtils;
 import org.springframework.cloud.function.web.source.FunctionAutoConfigurationWithRetriesIntegrationTests.ApplicationConfiguration;
 import org.springframework.cloud.function.web.source.FunctionAutoConfigurationWithRetriesIntegrationTests.RestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.SocketUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -65,7 +65,7 @@ public class FunctionAutoConfigurationWithRetriesIntegrationTests {
 
 	@BeforeAll
 	public static void init() {
-		System.setProperty("server.port", "" + SocketUtils.findAvailableTcpPort());
+		System.setProperty("server.port", "" + TestSocketUtils.findAvailableTcpPort());
 	}
 
 	@AfterAll

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/WebAppIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/WebAppIntegrationTests.java
@@ -35,9 +35,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.function.web.RestApplication;
+import org.springframework.cloud.function.web.TestSocketUtils;
 import org.springframework.cloud.function.web.source.WebAppIntegrationTests.ApplicationConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.util.SocketUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -66,7 +66,7 @@ public class WebAppIntegrationTests {
 
 	@BeforeAll
 	public static void init() {
-		System.setProperty("server.port", "" + SocketUtils.findAvailableTcpPort());
+		System.setProperty("server.port", "" + TestSocketUtils.findAvailableTcpPort());
 	}
 
 	@AfterAll


### PR DESCRIPTION
Resolves #825


Removed usage of SocketUtils where (currently) possible. 

### Remaining usages:
1. `org.springframework.cloud.function.test.FunctionalExporterTests`
2. `org.springframework.cloud.function.web.source.WebAppIntegrationTests`
3. `org.springframework.cloud.function.web.source.FunctionAutoConfigurationWithRetriesIntegrationTests`
4. `org.springframework.cloud.function.web.source.FunctionAutoConfigurationIntegrationTests`
5. `org.springframework.cloud.function.rsocket.RoutingBrokerTests`

#### Why - items 1-4
These rely on setting 
```java
"spring.cloud.function.web.export.sink.url=http://localhost:${my.port}",
"spring.cloud.function.web.export.source.url=http://localhost:${my.port}",
```
and are not able to replace `my.port` w/ `local.server.port` as they are loaded very early. See https://github.com/spring-cloud/spring-cloud-function/blob/be89c160cb17dbf93ef878cbd9b84220b8c0f6cf/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/FunctionExporterAutoConfiguration.java#L60 and https://github.com/spring-cloud/spring-cloud-function/blob/be89c160cb17dbf93ef878cbd9b84220b8c0f6cf/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/FunctionExporterAutoConfiguration.java#L67

The property is resolved in the locations above and it happens before the server starts up (aka `local.server.port` is not set). If we put a default in property such as `http://localhost:${local.server.port:5150} `it gets past this part of the code but then the WebClient does not re-evaluate the property and tries to use the fake `5150` port (it would need to re-evaluate the property after the server has started and the property is actually available).

#### Why - item 5
It needs 2 RSocket routing related ports that I am not sure whether or not they support `0`. I have not dug into these yet but will attempt to remove it here as well.

### TestSocketUtils
I created an as-slim-as-possible `TestSocketUtils` and co-located it (duplicated 2x) where its needed in each test module. They are marked deprecated/do-not-use. This is temporary and they will be consolidated or removed entirely w/ a follow-on ticket. 