### PR TITLE
Add support for lambda authorizers

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
@@ -168,7 +168,8 @@ final class AWSLambdaUtils {
 			String outputClassName = outputClass.getName();
 			if (outputClassName.equals("com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse") ||
 				outputClassName.equals("com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent") ||
-				outputClassName.equals("com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerResponseEvent")) {
+				outputClassName.equals("com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerResponseEvent") ||
+				outputClassName.equals("com.amazonaws.services.lambda.runtime.events.IamPolicyResponse")) {
 				return responseMessage.getPayload();
 			}
 		}


### PR DESCRIPTION
I added the `IamPolicyResponse` to the list of classes that don't get wrapped in the API Gateway response object.

I think this fixes my issue #822.