### PR TITLE
Exclude junit/hamcrest from spring-cloud-function-adapter-gcp classpath

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/pom.xml
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/pom.xml
@@ -68,6 +68,7 @@
 			<groupId>com.github.blindpirate</groupId>
 			<artifactId>junit5-capture-system-output-extension</artifactId>
 			<version>0.1.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Using `spring-cloud-function-adapter-gcp` transitively includes Junit and Hamcrest on the classpath because the `junit5-capture-system-output-extension` is included with compile scope.