### PR TITLE
Custom object type conversion is failing, when it has "headers" inside payload #882

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/SmartCompositeMessageConverter.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/SmartCompositeMessageConverter.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Salvatore Bernardo
  *
  */
 public class SmartCompositeMessageConverter extends CompositeMessageConverter {


### PR DESCRIPTION
This below step is removing the headers from payload instead of copying from it. We need the headers in the payload as is and should not be lost when passed to the spring cloud function.