### PR TITLE
Rename micrometer-tracing-api to micrometer-tracing

### DIFF
--- a/spring-cloud-function-observability/pom.xml
+++ b/spring-cloud-function-observability/pom.xml
@@ -30,7 +30,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-tracing-api</artifactId>
+			<artifactId>micrometer-tracing</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>

--- a/spring-cloud-function-observability/src/test/java/org/springframework/cloud/function/observability/ObservationFunctionAroundWrapperTests.java
+++ b/spring-cloud-function-observability/src/test/java/org/springframework/cloud/function/observability/ObservationFunctionAroundWrapperTests.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.function.observability;
 
 import java.util.function.Function;
 
-import io.micrometer.core.tck.TestObservationRegistry;
-import io.micrometer.core.tck.TestObservationRegistryAssert;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;


### PR DESCRIPTION
### What
Renames the `micrometer-tracing-api` dependency to `micrometer-tracing`.

### Why
The latest Spring Boot snapshot pulls in the latest Micrometer tracing milestone ([commit](https://github.com/spring-projects/spring-boot/commit/f1f7842a5d8678fba9da8479bfbf8e8ef54dcf88)) which in turn renames `micrometer-tracing-api` -> `micrometer-tracing` ([commit](https://github.com/micrometer-metrics/tracing/commit/dc1acde8cb50e0a87075a79d04c6f501fed027aa)).

