### PR TITLE
Remove use of reflection from CloudEventMessageUtils 

### DIFF
--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtilsAndBuilderTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtilsAndBuilderTests.java
@@ -97,4 +97,45 @@ public class CloudEventMessageUtilsAndBuilderTests {
 		assertThat(httpMessage.getHeaders().get("ce-specversion")).isNotNull();
 		assertThat(CloudEventMessageUtils.getSpecVersion(httpMessage)).isEqualTo("1.0");
 	}
+
+	@Test
+	void canonicalizeHeadersWithPossibleCopyReturnsCopyWithUpdatedHeadersWhenModified() {
+		// TODO add the following test cases
+		//
+		// defaultAttrs w/ unmodified keys -> not modified
+		// defaultAttrs w/ modified keys -> modified
+		// kafkaAttrs w/ (defaultAttrs+unmodified keys) -> modified
+		// amqpAttrs -> modified
+		// structured -> modified
+		Message<?> inputMessage = MessageBuilder.withPayload("hello")
+				.setHeader("ce_foo", "bar")
+				.setHeader("x", "x1")
+				.setHeader("x|x", "x2")
+				.build();
+
+		Message<?> updatedMessage = CloudEventMessageUtils.canonicalizeHeadersWithPossibleCopy(inputMessage);
+
+		assertThat(inputMessage).isNotSameAs(updatedMessage);
+		assertThat(updatedMessage.getHeaders())
+				.containsEntry("ce-foo", "bar")
+				.containsEntry("x", "x1")
+				.containsEntry("x|x", "x2");
+	}
+
+	@Test
+	void canonicalizeHeadersWithPossibleCopyReturnsSameInstanceWhenNotModified() {
+		Message<?> inputMessage = MessageBuilder.withPayload("hello")
+				.setHeader("ce-foo", "bar")
+				.setHeader("x", "x1")
+				.setHeader("x|x", "x2")
+				.build();
+
+		Message<?> updatedMessage = CloudEventMessageUtils.canonicalizeHeadersWithPossibleCopy(inputMessage);
+
+		assertThat(inputMessage).isSameAs(updatedMessage);
+		assertThat(updatedMessage.getHeaders())
+				.containsEntry("ce-foo", "bar")
+				.containsEntry("x", "x1")
+				.containsEntry("x|x", "x2");
+	}
 }

--- a/spring-cloud-function-observability/pom.xml
+++ b/spring-cloud-function-observability/pom.xml
@@ -30,7 +30,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-tracing-api</artifactId>
+			<artifactId>micrometer-tracing</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>

--- a/spring-cloud-function-observability/src/test/java/org/springframework/cloud/function/observability/ObservationFunctionAroundWrapperTests.java
+++ b/spring-cloud-function-observability/src/test/java/org/springframework/cloud/function/observability/ObservationFunctionAroundWrapperTests.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.function.observability;
 
 import java.util.function.Function;
 
-import io.micrometer.core.tck.TestObservationRegistry;
-import io.micrometer.core.tck.TestObservationRegistryAssert;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;


### PR DESCRIPTION
Fixes #892

⚠️ ⚠️ These changes build on top of the [PR for micrometer-tracing](https://github.com/spring-cloud/spring-cloud-function/pull/893) fix so act accordingly (squash/rebase once the other is merged OR just merge this one and close the other one) 