### PR TITLE
Deprecate SpringBootStreamHandler in favor of FunctionInvoker.

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/SpringBootStreamHandler.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/SpringBootStreamHandler.java
@@ -33,7 +33,9 @@ import org.springframework.cloud.function.context.AbstractSpringFunctionAdapterI
 /**
  * @author Dave Syer
  * @author Oleg Zhurakousky
+ * @deprecated since 3.2.7 in favor of {@link FunctionInvoker}
  */
+@Deprecated
 public class SpringBootStreamHandler extends AbstractSpringFunctionAdapterInitializer<Context>
 		implements RequestStreamHandler {
 


### PR DESCRIPTION
`SpringBootStreamHandler` is not mentioned in docs as a way to configure AWS lambdas. Additionally it extends deprecated `AbstractSpringFunctionAdapterInitializer`. Docs guide users to use `FunctionInvoker` instead.

Seems that `SpringBootStreamHandler` should be deprecated together with other handlers in favor of `FunctionInvoker`.

The one missing functionality I see is handling function that takes `InputStream`, that `SpringBootStreamHandler` supported and `FunctionInvoker` does not.

If this change makes sense, `SpringBootStreamHandler` should be also removed from the "Build file setup" for Gradle section in reference docs.