### PR TITLE
update on AWSLambdaUtils visibility

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
@@ -37,7 +37,7 @@ import org.springframework.messaging.support.MessageBuilder;
  * @author Oleg Zhurakousky
  *
  */
-final class AWSLambdaUtils {
+public final class AWSLambdaUtils {
 
 	private static Log logger = LogFactory.getLog(AWSLambdaUtils.class);
 


### PR DESCRIPTION
Making class AWSLambdaUtils public so the AWS_CONTEXT constant can be accessed. 

Please see my latest comment on #910

“@pivotal-cla This is an Obvious Fix”