### PR TITLE
Conditional loading of AVRO message converter

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
@@ -166,6 +166,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(name = "org.apache.avro.Schema")
+	@ConditionalOnProperty(value = "spring.cloud.stream.avro.enabled", havingValue = "true", matchIfMissing = true)
 	static class AvroSchemaMessageConverterConfiguration {
 
 		@Bean

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationConditionalLoadingTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationConditionalLoadingTests.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
  * Tests the conditional loading aspects of the {@link ContextFunctionCatalogAutoConfiguration}.
  *
  * @author Chris Bono
+ * @author Soby Chacko
  */
 public class ContextFunctionCatalogAutoConfigurationConditionalLoadingTests {
 
@@ -56,6 +57,13 @@ public class ContextFunctionCatalogAutoConfigurationConditionalLoadingTests {
 		void avroSchemaMessageConverterBeansLoadedWhenAvroOnClasspath() {
 			contextRunner.run((context) -> assertThat(context).hasSingleBean(AvroSchemaServiceManager.class)
 				.hasSingleBean(AvroSchemaMessageConverter.class));
+		}
+
+		@Test
+		void avroSchemaMessageConverterBeansNotLoadedWhenAvroOnClasspathButDisabledThroughProperty() {
+			contextRunner.withPropertyValues("spring.cloud.stream.avro.enabled:false")
+				.run((context) -> assertThat(context).doesNotHaveBean(AvroSchemaServiceManager.class)
+					.doesNotHaveBean(AvroSchemaMessageConverter.class));
 		}
 
 		@Test


### PR DESCRIPTION
Introducing a property to disable loading the AVRO message converter. When spring.cloud.stream.avro.enabled is set to false, the converter is not loaded. By default, it is enabled.

Resolves https://github.com/spring-cloud/spring-cloud-function/issues/854