### PR TITLE
Update docs about shade-plugin-setup and Spring Boot 2.7

### DIFF
--- a/docs/src/main/asciidoc/adapters/aws-intro.adoc
+++ b/docs/src/main/asciidoc/adapters/aws-intro.adoc
@@ -106,7 +106,9 @@ manifest, using the `Start-Class` attribute (which will be added for you by the 
 tooling if you use the starter parent). If there is no `Start-Class` in your manifest you can
 use an environment variable or system property `MAIN_CLASS` when you deploy the function to AWS.
 
-If you are not using the functional bean definitions but relying on Spring Boot's auto-configuration, and are not depending on `spring-boot-starter-parent`, then additional transformers must be configured as part of the maven-shade-plugin execution.
+If you are not using the functional bean definitions but relying on Spring Boot's auto-configuration,
+and are not depending on `spring-boot-starter-parent`,
+then additional transformers must be configured as part of the maven-shade-plugin execution.
 
 [[shade-plugin-setup]]
 [source, xml]

--- a/docs/src/main/asciidoc/adapters/aws-intro.adoc
+++ b/docs/src/main/asciidoc/adapters/aws-intro.adoc
@@ -106,8 +106,7 @@ manifest, using the `Start-Class` attribute (which will be added for you by the 
 tooling if you use the starter parent). If there is no `Start-Class` in your manifest you can
 use an environment variable or system property `MAIN_CLASS` when you deploy the function to AWS.
 
-If you are not using the functional bean definitions but relying on Spring Boot's auto-configuration,
-then additional transformers must be configured as part of the maven-shade-plugin execution.
+If you are not using the functional bean definitions but relying on Spring Boot's auto-configuration, and are not depending on `spring-boot-starter-parent`, then additional transformers must be configured as part of the maven-shade-plugin execution.
 
 [[shade-plugin-setup]]
 [source, xml]
@@ -119,7 +118,7 @@ then additional transformers must be configured as part of the maven-shade-plugi
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-maven-plugin</artifactId>
-			<version>2.7.1</version>
+			<version>2.7.4</version>
 		</dependency>
 	</dependencies>
 	<executions>
@@ -137,6 +136,12 @@ then additional transformers must be configured as part of the maven-shade-plugi
 					</transformer>
 					<transformer implementation="org.springframework.boot.maven.PropertiesMergingResourceTransformer">
 						<resource>META-INF/spring.factories</resource>
+					</transformer>
+					<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+						<resource>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</resource>
+					</transformer>
+					<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+						<resource>META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports</resource>
 					</transformer>
 					<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
 						<resource>META-INF/spring.schemas</resource>

--- a/docs/src/main/asciidoc/adapters/aws-intro.adoc
+++ b/docs/src/main/asciidoc/adapters/aws-intro.adoc
@@ -241,6 +241,8 @@ shadowJar {
 	append 'META-INF/spring.handlers'
 	append 'META-INF/spring.schemas'
 	append 'META-INF/spring.tooling'
+	append 'META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports'
+	append 'META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports'
 	transform(PropertiesFileTransformer) {
 		paths = ['META-INF/spring.factories']
 		mergeStrategy = "append"


### PR DESCRIPTION
With new AutoConfiguration registration introduced in Spring Boot 2.7 there are two files missing from `shade` plugin transformations configuration.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#configuration-of-maven-shade-plugin.

Moreover, if `spring-boot-starter-parent` is already used as parent, the transformations configuration is not required (as those are set up in parent)