### PR TITLE
Exclude spring logging for azure

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/pom.xml
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/pom.xml
@@ -31,6 +31,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>spring-boot-starter-logging</artifactId>
+					<groupId>org.springframework.boot</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>

--- a/spring-cloud-function-samples/function-sample-azure-kafka-trigger/pom.xml
+++ b/spring-cloud-function-samples/function-sample-azure-kafka-trigger/pom.xml
@@ -36,12 +36,6 @@
 		<dependency>
 			<artifactId>spring-cloud-function-adapter-azure</artifactId>
 			<groupId>org.springframework.cloud</groupId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-logging</artifactId>
-				</exclusion>
-			</exclusions> 
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-function-samples/function-sample-azure-timer-trigger/pom.xml
+++ b/spring-cloud-function-samples/function-sample-azure-timer-trigger/pom.xml
@@ -36,12 +36,6 @@
 		<dependency>
 			<artifactId>spring-cloud-function-adapter-azure</artifactId>
 			<groupId>org.springframework.cloud</groupId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-logging</artifactId>
-				</exclusion>
-			</exclusions> 
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
 - exclude the spring-boot-starter-logging depedency from azure adapter.
 - clean the azure samples.

Resolves #945