### PR TITLE
Make CloudEventsFunctionExtensionConfiguration public to allow import

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionExtensionConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionExtensionConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.messaging.Message;
  * @since 3.1
  */
 @Configuration(proxyBeanMethods = false)
-class CloudEventsFunctionExtensionConfiguration {
+public class CloudEventsFunctionExtensionConfiguration {
 
 	// The following two beans are intended to be mutually exclusive. Only one should be activated based
 	// on the presence of Cloud Event SDK API


### PR DESCRIPTION
It is not possible to load CloudEventsFunctionExtensionConfiguration using @ImportAutoConfiguration() if it is package private.