### PR TITLE
#951 acceptContentTypes not used

### DIFF
--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FunctionHandlerMapping.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FunctionHandlerMapping.java
@@ -84,7 +84,7 @@ public class FunctionHandlerMapping extends RequestMappingHandlerMapping
 			path = path.substring(this.prefix.length());
 		}
 		Object function = FunctionWebRequestProcessingHelper
-				.findFunction(this.functionProperties, request.getRequest().getMethod(), this.functions, request.getAttributes(), path, new String[] {});
+				.findFunction(this.functionProperties, request.getRequest().getMethod(), this.functions, request.getAttributes(), path);
 
 		if (function != null) {
 			if (this.logger.isDebugEnabled()) {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializer.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializer.java
@@ -227,9 +227,8 @@ class FunctionEndpointFactory {
 			function = this.functionCatalog.lookup(Function.class, handler);
 		}
 		else {
-			String[] accept = FunctionWebRequestProcessingHelper.acceptContentTypes(request.headers().accept());
 			function = FunctionWebRequestProcessingHelper.findFunction(this.functionProperties, request.method(), functionCatalog, request.attributes(),
-					request.path(), accept);
+					request.path());
 		}
 		return function;
 	}

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/mvc/FunctionHandlerMapping.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/mvc/FunctionHandlerMapping.java
@@ -98,7 +98,7 @@ public class FunctionHandlerMapping extends RequestMappingHandlerMapping
 		}
 
 		Object function = FunctionWebRequestProcessingHelper.findFunction(this.functionProperties, HttpMethod.resolve(request.getMethod()),
-				this.functions, new HttpRequestAttributeDelegate(request), path, new String[] {});
+				this.functions, new HttpRequestAttributeDelegate(request), path);
 		if (function != null) {
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug("Found function for GET: " + path);


### PR DESCRIPTION
Remove acceptContentTypes for #951 

(It can be noted that the functionCatalog.lookup method has the same behavior with an empty string or a null acceptContentTypes parameter)