### PR TITLE
Updated spring frameworks to release version on function-sample-aws-routing

### DIFF
--- a/spring-cloud-function-samples/function-sample-aws-routing/pom.xml
+++ b/spring-cloud-function-samples/function-sample-aws-routing/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>2.7.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -24,7 +24,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<wrapper.version>1.0.27.RELEASE</wrapper.version>
 		<aws-lambda-events.version>2.0.2</aws-lambda-events.version>
-		<spring-cloud-function.version>4.0.0-SNAPSHOT</spring-cloud-function.version>
+		<spring-cloud-function.version>3.2.8</spring-cloud-function.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
The snapshot versions use Java 17 while AWS Lambda only supports Java 11 natively. Since this is a sample project, this can bring confusion to people learning serverless and this framework.
