### PR TITLE
Update gradle main class config

### DIFF
--- a/spring-cloud-function-samples/function-sample-aws/build.gradle
+++ b/spring-cloud-function-samples/function-sample-aws/build.gradle
@@ -50,7 +50,7 @@ assemble.dependsOn = [shadowJar, thinJar]
 
 jar {
 	manifest {
-		attributes 'Main-Class': 'example.Config'
+		attributes 'Main-Class': 'example.FunctionConfiguration'
 	}
 }
 


### PR DESCRIPTION
The main class is incorrect ("example.Config" does not exist), so the lambda function cannot recognize the main class of the jar file.
Updated gradle main class config to "example.FunctionConfiguration"