### PR TITLE
fix: resolve function type from non-parameterized Kotlin class that i…

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/FunctionContextUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/FunctionContextUtils.java
@@ -75,16 +75,14 @@ public abstract class FunctionContextUtils {
 			param = registry.getType(actualName);
 		}
 
-		if (param != null) {
-			return param;
+		if (param == null) {
+			param = definition.getResolvableType().getType();
 		}
-		else {
-			Type t = definition.getResolvableType().getType();
-			if (!(t instanceof ParameterizedType) && beanClass != null) {
-				return FunctionTypeUtils.discoverFunctionTypeFromClass(definition.getBeanClass());
-			}
-			return t;
+
+		if (!(param instanceof ParameterizedType) && beanClass != null) {
+			return FunctionTypeUtils.discoverFunctionTypeFromClass(beanClass);
 		}
+		return param;
 	}
 
 	public static Class<?>[] getParamTypesFromBeanDefinitionFactory(Class<?> factory,


### PR DESCRIPTION
…mplements a function type

Resolves #925
Resolves #940
Resolves #956
Resolves #964

This should fix the problem I described in #940. Please have a close look as I'm not comfortable with all those types and classes flying around, e.g. I don't understand why the source even makes a difference and why we are calling `discoverFunctionTypeFromClass` with the `beanClass` and not, e.g., the value of `param`.