### PR TITLE
fixed a ClassCastException when returning an Iterable that couldn't be cast into Collection

### DIFF
--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/FunctionWebRequestProcessingHelper.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/FunctionWebRequestProcessingHelper.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.function.web.util;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -126,8 +126,8 @@ public final class FunctionWebRequestProcessingHelper {
 		}
 
 		return Mono.from(pResult).map(v -> {
-			if (v instanceof Iterable) {
-				List aggregatedResult = (List) ((Collection) v).stream().map(m -> {
+			if (v instanceof Iterable i) {
+				List aggregatedResult = (List) StreamSupport.stream(i.spliterator(), false).map(m -> {
 					return m instanceof Message ? processMessage(responseOkBuilder, (Message<?>) m) : m;
 				}).collect(Collectors.toList());
 				return responseOkBuilder.header("content-type", "application/json").body(aggregatedResult);


### PR DESCRIPTION
(resubmitted PR because of history rewrite on upstream)
original description:

I was working on a pagable web function and noticed a `ClassCastException` when returning any `Page<?>`. The reason seems to be a check `instanceof Iterable` which then triggers a cast to `Collection`. While this probably works in many if not most cases, `Page` (`org.springframework.data.domain`) is definitely an exception.

I tried to provide a minimally invasive fix, this shouldn't affect functionality at all and all test are still passing.

While this fixes the `ClassCastException` I'm not entirely happy with the result for my use case. Maybe there are better ideas or this is a topic for a separate issue:
The current approach always converts any `Iterable`s to a new `List` which could mean loosing information from it, like in the case of a `Page` which contains additionally to the iterable items also information about the total items, pages, page size, etc.
It seemed the current approach is only required to treat `Iterable`s of `Message`s specially, but when I changed the code to only convert those some tests failed, so maybe I'm missing something here.

Anyways in this case it would be nice to programmatically opt-out of the conversion somehow. 
If you like I can prepare a repository with a minimal test case.

Thanks for your work