### PR TITLE
JsonMessageConverter Object.class target type

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/JsonMessageConverter.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/JsonMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class JsonMessageConverter extends AbstractMessageConverter {
 			if (StringUtils.hasText(mimeType.getParameter("type"))) {
 				return true;
 			}
-			return false;
+			return targetClass == Object.class;
 		}
 		return true;
 	}

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/JsonMessageConverterTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/JsonMessageConverterTests.java
@@ -43,7 +43,7 @@ public class JsonMessageConverterTests {
 
 		message = MessageBuilder.withPayload("{\"name\":\"bill\"}").setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON).build();
 		assertThat(converter.canConvertFrom(message, Person.class)).isTrue();
-		assertThat(converter.canConvertFrom(message, Object.class)).isFalse();
+		assertThat(converter.canConvertFrom(message, Object.class)).isTrue();
 		assertThat(converter.canConvertFrom(message, null)).isFalse();
 		assertThat(converter.convertFromInternal(message, Person.class, null)).isInstanceOf(Person.class);
 


### PR DESCRIPTION
 - If Object.class is provided as the target type, the behavior in JsonMessageConverter is changed and it creates errors when converting in certain scenarios. Restore the previous behavior for Object.class target type in JsonMessageConverter.

Resolves https://github.com/spring-cloud/spring-cloud-function/issues/1045