### PR TITLE
Do not convert text/plain content to JSON

### DIFF
--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
@@ -193,7 +193,6 @@ public class SimpleFunctionRegistryTests {
 		assertThat(result).isEqualTo("{\"HELLO\":\"WORLD\"}");
 	}
 
-	// TODO: Once bug is fixed this test (last entry) will fully pass and this COMMENT should be removed
 	@ParameterizedTest
 	@ValueSource(strings = {"[hello", "hello]", "[hello]"})
 	void textContentTypeWithValueWrappedBracketsIsOk(String inputMessagePayloadValue) {

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpGetIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpGetIntegrationTests.java
@@ -128,7 +128,6 @@ public class HttpGetIntegrationTests {
 		assertThat(result.getBody()).isEqualTo("foo");
 	}
 
-	// TODO: Once bug is fixed this test (last entry) will fully pass and this COMMENT should be removed
 	@ParameterizedTest
 	@ValueSource(strings = {"[hello", "hello]", "[hello]"})
 	void textContentTypeWithValueWrappedBracketsIsOk(String inputMessagePayloadValue) throws URISyntaxException {


### PR DESCRIPTION
The origin of this issue is https://stackoverflow.com/questions/76444130/spring-data-flow-log-sink-how-to-log-plain-text-message/76475655#76475655 .

In a nutshell, if user specifies content type of `text/plain` the input string fails during check the string represents a JSON collection. This code proposal avoids this check when user specifies content type `text/plain`.

**NOTE:** This may be a regression of https://github.com/spring-cloud/spring-cloud-function/issues/694

**NOTE:** There are 2 commits w/ the 1st commit merely illustrating the problem via 2 newly added tests. Please squash as the only value of the separate commits are to show the reviewer how to reproduce the problem if they choose to, etc..