### PR TITLE
aws-gateway-authorizer-with-reactive

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
@@ -1359,7 +1359,6 @@ public class FunctionInvokerTests {
 		invoker.handleRequest(targetStream, output, null);
 
 		Map result = mapper.readValue(output.toByteArray(), Map.class);
-		System.out.println(result);
 		assertThat(result.get("body")).isNull();
 		assertThat(result.get("principalId")).isNotNull();
 	}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
@@ -1860,8 +1860,7 @@ public class FunctionInvokerTests {
 									.withResource(
 										List.of(v)).withEffect("Allow").build()
 							)
-						)
-						.build()
+						).build()
 					).build()
 				);
 		}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -38,6 +39,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerResponseEvent;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.IamPolicyResponse;
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent;
@@ -1346,6 +1348,22 @@ public class FunctionInvokerTests {
 		assertThat(result.get("body")).isEqualTo("\"hello\"");
 	}
 
+	@Test
+	public void testShouldNotWrapIamPolicyResponse() throws Exception {
+		System.setProperty("MAIN_CLASS", ApiGatewayConfiguration.class.getName());
+		System.setProperty("spring.cloud.function.definition", "outputPolicyResponse");
+		FunctionInvoker invoker = new FunctionInvoker();
+
+		InputStream targetStream = new ByteArrayInputStream(this.apiGatewayEvent.getBytes());
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		invoker.handleRequest(targetStream, output, null);
+
+		Map result = mapper.readValue(output.toByteArray(), Map.class);
+		System.out.println(result);
+		assertThat(result.get("body")).isNull();
+		assertThat(result.get("principalId")).isNotNull();
+	}
+
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void testApiGatewayEventConsumer() throws Exception {
@@ -1827,6 +1845,25 @@ public class FunctionInvokerTests {
 				String body = (String) v.get("body");
 				return body;
 			};
+		}
+
+		@Bean
+		public Function<Mono<String>, Mono<IamPolicyResponse>> outputPolicyResponse() {
+			return input ->
+				input.map(v -> IamPolicyResponse.builder()
+					.withPrincipalId("principalId")
+					.withPolicyDocument(IamPolicyResponse.PolicyDocument.builder()
+						.withVersion("2012-10-17")
+						.withStatement(
+							List.of(
+								IamPolicyResponse.Statement.builder().withAction("execute-api:Invoke")
+									.withResource(
+										List.of(v)).withEffect("Allow").build()
+							)
+						)
+						.build()
+					).build()
+				);
 		}
 	}
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -148,9 +148,6 @@ public final class FunctionTypeUtils {
 		if (type == null) {
 			return null;
 		}
-		if (isPublisher(type)) {
-			type = getImmediateGenericType(type, 0);
-		}
 		return TypeResolver.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null);
 	}
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -145,10 +145,8 @@ public final class FunctionTypeUtils {
 	 * @return instance of {@link Class} as raw representation of the provided {@link Type}
 	 */
 	public static Class<?> getRawType(Type type) {
-		if (type == null) {
-			return null;
-		}
-		return TypeResolver.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null);
+		return type != null ? TypeResolver
+			.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null) : null;
 	}
 
 	/**

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -145,8 +145,13 @@ public final class FunctionTypeUtils {
 	 * @return instance of {@link Class} as raw representation of the provided {@link Type}
 	 */
 	public static Class<?> getRawType(Type type) {
-		return type != null ? TypeResolver
-				.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null) : null;
+		if (type == null) {
+			return null;
+		}
+		if (isPublisher(type) || isMessage(type)) {
+			type = getImmediateGenericType(type, 0);
+		}
+		return TypeResolver.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null);
 	}
 
 	/**

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -148,7 +148,7 @@ public final class FunctionTypeUtils {
 		if (type == null) {
 			return null;
 		}
-		if (isPublisher(type) || isMessage(type)) {
+		if (isPublisher(type)) {
 			type = getImmediateGenericType(type, 0);
 		}
 		return TypeResolver.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null);

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -146,7 +146,7 @@ public final class FunctionTypeUtils {
 	 */
 	public static Class<?> getRawType(Type type) {
 		return type != null ? TypeResolver
-			.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null) : null;
+				.resolveRawClass(type instanceof GenericArrayType ? type : TypeResolver.reify(type), null) : null;
 	}
 
 	/**


### PR DESCRIPTION
I want to use Lambda as an AWS API Gateway authorizer. In the case where the cloud function return type is Flux or Mono the response is wrapped because these classes are not part of  `com.amazonaws.services.lambda.runtime.events.` AWS API Gateway fails on error:


```
 Execution failed due to configuration error: Invalid JSON in response: Unrecognized field "isBase64Encoded" , not marked as ignorable
```