### PR TITLE
Update function definition name in log message to avoid confusion

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/RoutingFunction.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/RoutingFunction.java
@@ -205,9 +205,9 @@ public class RoutingFunction implements Function<Object, Object> {
 	private FunctionInvocationWrapper functionFromDefinition(String definition) {
 		FunctionInvocationWrapper function = this.resolveFunction(definition);
 		Assert.notNull(function, "Failed to lookup function to route based on the value of 'spring.cloud.function.definition' property '"
-				+ functionProperties.getDefinition() + "'");
+				+ definition + "'");
 		if (logger.isInfoEnabled()) {
-			logger.info("Resolved function from provided [definition] property " + functionProperties.getDefinition());
+			logger.info("Resolved function from provided [definition] property " + definition);
 		}
 		return function;
 	}


### PR DESCRIPTION
In the current version, if you pass a name of a non-existent function via a `spring.cloud.function.definition` header, the corresponding error message will reference a `null` function instead of the correct name, e.g.:

```
java.lang.IllegalArgumentException: Failed to lookup function to route based on the value of 'spring.cloud.function.definition' property 'null'
```

which can be confusing for new users.

It seems that the message is supposed to print the value of `definition` passed to `functionFromDefinition` via arguments as the code uses that name value to do the lookup.

Sample command for testing:

```
curl localhost:8080/functionRouter -H 'spring.cloud.function.definition: doesntexist'
```