### PR TITLE
Fix JsonMessageConverter mimetype NullPointerException

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/JsonMessageConverter.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/JsonMessageConverter.java
@@ -78,7 +78,7 @@ public class JsonMessageConverter extends AbstractMessageConverter {
 	private boolean canDiscoverConvertToType(Message<?> message, Class<?> targetClass) {
 		if (targetClass == null || targetClass == Object.class) {
 			MimeType mimeType = getMimeType(message.getHeaders());
-			if (StringUtils.hasText(mimeType.getParameter("type"))) {
+			if (mimeType != null && StringUtils.hasText(mimeType.getParameter("type"))) {
 				return true;
 			}
 			return false;

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/JsonMessageConverterTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/JsonMessageConverterTests.java
@@ -40,6 +40,8 @@ public class JsonMessageConverterTests {
 
 		Message<String> message = MessageBuilder.withPayload("{\"name\":\"bill\"}").build();
 		assertThat(converter.canConvertFrom(message, Person.class)).isTrue();
+		assertThat(converter.canConvertFrom(message, Object.class)).isFalse();
+		assertThat(converter.canConvertFrom(message, null)).isFalse();
 
 		message = MessageBuilder.withPayload("{\"name\":\"bill\"}").setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON).build();
 		assertThat(converter.canConvertFrom(message, Person.class)).isTrue();


### PR DESCRIPTION
Fixes the `NullPointerException` in `JsonMessageConverter` when no mime type can be retrieved from the message.

### The issue
In a Spring Cloud Stream app, when the following conditions are true:

* A Spring message has a `byte[]` as its payload.
* A Spring message's `contentType` header is removed by a function which is **NOT** the last function in a function definition.

When both conditions are met and a function-definition is connected to an output binding (e.g. `Function<?,?>`), then an `NullPointerException` is logged as a `WARN` and the message seems to still be successfully moved through the whole function and is successfully published to an end system.

But if instead, the function sends a message to an output binding via `StreamBridge`, this would cause the function to outright fail to publish and fail to consume the message.

### To reproduce the issue

1. Clone the [Function Composition Sample](https://github.com/spring-cloud/spring-cloud-stream-samples/tree/main/multi-functions-samples/function-composition-rabbit)
2. Upgrade `spring-boot-starter-parent` to `3.2.2`
3. Upgrade `spring-cloud.version` to `2023.0.0`
4. Change the `uppercase()` function to:
	```java
	@Bean
	public Function<Message<String>, Message<byte[]>> uppercase() {
		return msg -> {
			String v = msg.getPayload();
			v =  v.toUpperCase();
			System.out.println("Uppercase: " + v);
			return MessageBuilder.withPayload(v.getBytes(StandardCharsets.UTF_8)) // Error Condition 1
					.copyHeaders(msg.getHeaders())
					.removeHeader(MessageHeaders.CONTENT_TYPE) // Error Condition 2
					.build();
		};
	}
	```
5. change the function declaration for `echo()` to:
	```java
	public Function<?, ?> echo()
	```
6. Send a message to the rabbit exchange, `uppercase-in`.

The following exception will then be thrown:

```java
java.lang.NullPointerException: Cannot invoke "org.springframework.util.MimeType.getParameter(String)" because "mimeType" is null
	at org.springframework.cloud.function.context.config.JsonMessageConverter.canDiscoverConvertToType(JsonMessageConverter.java:81) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.config.JsonMessageConverter.canConvertFrom(JsonMessageConverter.java:75) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.messaging.converter.AbstractMessageConverter.fromMessage(AbstractMessageConverter.java:180) ~[spring-messaging-6.1.3.jar:6.1.3]
	at org.springframework.messaging.converter.AbstractMessageConverter.fromMessage(AbstractMessageConverter.java:174) ~[spring-messaging-6.1.3.jar:6.1.3]
	at org.springframework.cloud.function.context.config.SmartCompositeMessageConverter.fromMessage(SmartCompositeMessageConverter.java:63) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.convertInputMessageIfNecessary(SimpleFunctionRegistry.java:1357) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.convertInputIfNecessary(SimpleFunctionRegistry.java:1120) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.doApply(SimpleFunctionRegistry.java:728) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.lambda$andThen$0(SimpleFunctionRegistry.java:652) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.doApply(SimpleFunctionRegistry.java:731) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.apply(SimpleFunctionRegistry.java:580) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.observability.ObservationFunctionAroundWrapper.lambda$nonReactorStream$0(ObservationFunctionAroundWrapper.java:50) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at io.micrometer.observation.Observation.observe(Observation.java:565) ~[micrometer-observation-1.12.2.jar:1.12.2]
	at org.springframework.cloud.function.observability.ObservationFunctionAroundWrapper.nonReactorStream(ObservationFunctionAroundWrapper.java:50) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.observability.ObservationFunctionAroundWrapper.doApply(ObservationFunctionAroundWrapper.java:45) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.FunctionAroundWrapper.apply(FunctionAroundWrapper.java:47) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry$FunctionInvocationWrapper.apply(SimpleFunctionRegistry.java:577) ~[spring-cloud-function-context-4.1.0.jar:4.1.0]
	at org.springframework.cloud.stream.function.PartitionAwareFunctionWrapper.apply(PartitionAwareFunctionWrapper.java:92) ~[spring-cloud-stream-4.1.0.jar:4.1.0]
	at org.springframework.cloud.stream.function.FunctionConfiguration$FunctionWrapper.apply(FunctionConfiguration.java:832) ~[spring-cloud-stream-4.1.0.jar:4.1.0]
	at org.springframework.cloud.stream.function.FunctionConfiguration$FunctionToDestinationBinder$1.handleMessageInternal(FunctionConfiguration.java:661) ~[spring-cloud-stream-4.1.0.jar:4.1.0]
	at org.springframework.integration.handler.AbstractMessageHandler.doHandleMessage(AbstractMessageHandler.java:105) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.handler.AbstractMessageHandler.handleMessage(AbstractMessageHandler.java:73) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.dispatcher.AbstractDispatcher.tryOptimizedDispatch(AbstractDispatcher.java:132) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.dispatcher.UnicastingDispatcher.doDispatch(UnicastingDispatcher.java:133) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.dispatcher.UnicastingDispatcher.dispatch(UnicastingDispatcher.java:106) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.channel.AbstractSubscribableChannel.doSend(AbstractSubscribableChannel.java:72) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.channel.AbstractMessageChannel.sendInternal(AbstractMessageChannel.java:378) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.channel.AbstractMessageChannel.sendWithMetrics(AbstractMessageChannel.java:349) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.channel.AbstractMessageChannel.send(AbstractMessageChannel.java:329) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.channel.AbstractMessageChannel.send(AbstractMessageChannel.java:302) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.messaging.core.GenericMessagingTemplate.doSend(GenericMessagingTemplate.java:187) ~[spring-messaging-6.1.3.jar:6.1.3]
	at org.springframework.messaging.core.GenericMessagingTemplate.doSend(GenericMessagingTemplate.java:166) ~[spring-messaging-6.1.3.jar:6.1.3]
	at org.springframework.messaging.core.GenericMessagingTemplate.doSend(GenericMessagingTemplate.java:47) ~[spring-messaging-6.1.3.jar:6.1.3]
	at org.springframework.messaging.core.AbstractMessageSendingTemplate.send(AbstractMessageSendingTemplate.java:109) ~[spring-messaging-6.1.3.jar:6.1.3]
	at org.springframework.integration.endpoint.MessageProducerSupport.lambda$sendMessage$1(MessageProducerSupport.java:262) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at io.micrometer.observation.Observation.observe(Observation.java:499) ~[micrometer-observation-1.12.2.jar:1.12.2]
	at org.springframework.integration.endpoint.MessageProducerSupport.sendMessage(MessageProducerSupport.java:262) ~[spring-integration-core-6.2.1.jar:6.2.1]
	at org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter.access$400(AmqpInboundChannelAdapter.java:69) ~[spring-integration-amqp-6.2.1.jar:6.2.1]
	at org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter$Listener.lambda$onMessage$0(AmqpInboundChannelAdapter.java:369) ~[spring-integration-amqp-6.2.1.jar:6.2.1]
	at org.springframework.retry.support.RetryTemplate.doExecute(RetryTemplate.java:335) ~[spring-retry-2.0.5.jar:na]
	at org.springframework.retry.support.RetryTemplate.execute(RetryTemplate.java:227) ~[spring-retry-2.0.5.jar:na]
	at org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter$Listener.onMessage(AmqpInboundChannelAdapter.java:365) ~[spring-integration-amqp-6.2.1.jar:6.2.1]
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.doInvokeListener(AbstractMessageListenerContainer.java:1682) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.actualInvokeListener(AbstractMessageListenerContainer.java:1604) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.invokeListener(AbstractMessageListenerContainer.java:1592) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.doExecuteListener(AbstractMessageListenerContainer.java:1583) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.executeListenerAndHandleException(AbstractMessageListenerContainer.java:1528) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.lambda$executeListener$8(AbstractMessageListenerContainer.java:1506) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at io.micrometer.observation.Observation.observe(Observation.java:499) ~[micrometer-observation-1.12.2.jar:1.12.2]
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.executeListener(AbstractMessageListenerContainer.java:1506) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer.doReceiveAndExecute(SimpleMessageListenerContainer.java:1042) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer.receiveAndExecute(SimpleMessageListenerContainer.java:989) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer$AsyncMessageProcessingConsumer.mainLoop(SimpleMessageListenerContainer.java:1377) ~[spring-rabbit-3.1.1.jar:3.1.1]
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer$AsyncMessageProcessingConsumer.run(SimpleMessageListenerContainer.java:1279) ~[spring-rabbit-3.1.1.jar:3.1.1]
```