### PR TITLE
Adds reproducer for protobuf msg conversion issue (#1094)

### DIFF
--- a/spring-cloud-function-context/pom.xml
+++ b/spring-cloud-function-context/pom.xml
@@ -109,6 +109,14 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Protobuf -->
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>3.25.1</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- Actuator -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Conversion of protobuf messages fails if the encoded message looks like a JSON string.
Added a test that reproduces the issue.

Reproduces #1094 