### PR TITLE
GH-1085 Fixes spring-cloud-function-adapter-gcp

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/layout/GcfJarLayout.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/layout/GcfJarLayout.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.springframework.boot.loader.tools.CustomLoaderLayout;
 import org.springframework.boot.loader.tools.Layouts;
 import org.springframework.boot.loader.tools.LoaderClassesWriter;
+import org.springframework.boot.loader.tools.LoaderImplementation;
 import org.springframework.cloud.function.adapter.gcp.GcfJarLauncher;
 
 /**
@@ -46,7 +47,7 @@ public class GcfJarLayout extends Layouts.Jar implements CustomLoaderLayout {
 
 	@Override
 	public void writeLoadedClasses(LoaderClassesWriter writer) throws IOException {
-		writer.writeLoaderClasses();
+		writer.writeLoaderClasses(LoaderImplementation.CLASSIC);
 
 		String jarName = LAUNCHER_NAME.replaceAll("\\.", "/") + ".class";
 		writer.writeEntry(

--- a/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
+++ b/spring-cloud-function-samples/function-sample-gcp-http/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-function-adapter-gcp</artifactId>
-			<version>4.1.0-SNAPSHOT</version>
+			<version>${spring-cloud-function.version}</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
This updates the GcfJarLayout to write the classic loader classes that are currently in use by the spring-cloud-function project. Before this update the default loaders were being used every time which stopped the adapter from working. 

This also updates the pom for function-sample-gcp-http to use the local development snapshot of spring-cloud-function-adapter-gcp. This sample has been built, deployed, and tested successfully as a version 2 GCP Serverless Function with an HTTP entry.