### PR TITLE
Doc and Javadoc typos fix

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-function/programming-model.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-function/programming-model.adoc
@@ -195,8 +195,9 @@ The `MessageRoutingCallback` is a strategy to assist with determining the name o
 [source, java]
 ----
 public interface MessageRoutingCallback {
-	FunctionRoutingResult routingResult(Message<?> message);
-	. . .
+    default String routingResult(Message<?> message) {
+        return (String) message.getHeaders().get("spring.cloud.function.definition");
+    }
 }
 ----
 

--- a/docs/modules/ROOT/pages/spring-cloud-function/programming-model.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-function/programming-model.adoc
@@ -196,8 +196,8 @@ The `MessageRoutingCallback` is a strategy to assist with determining the name o
 ----
 public interface MessageRoutingCallback {
     default String routingResult(Message<?> message) {
-		return (String) message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION);
-	}
+	    return (String) message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION);
+    }
 }
 ----
 

--- a/docs/modules/ROOT/pages/spring-cloud-function/programming-model.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-function/programming-model.adoc
@@ -196,8 +196,8 @@ The `MessageRoutingCallback` is a strategy to assist with determining the name o
 ----
 public interface MessageRoutingCallback {
     default String routingResult(Message<?> message) {
-        return (String) message.getHeaders().get("spring.cloud.function.definition");
-    }
+		return (String) message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION);
+	}
 }
 ----
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/MessageRoutingCallback.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/MessageRoutingCallback.java
@@ -33,7 +33,7 @@ import org.springframework.messaging.Message;
 public interface MessageRoutingCallback {
 
 	/**
-	 * Computes and returns the instance of {@link FunctionRoutingResult} which encapsulates,
+	 * Computes and returns the instance of {@link String} which encapsulates,
 	 * at the very minimum, function definition.
 	 * <br><br>
 	 * Providing such message is primarily an optimization feature. It could be useful for cases
@@ -42,7 +42,7 @@ public interface MessageRoutingCallback {
 	 * message for downstream use didn't exist, resulting in repeated transformation, type conversion etc.
 	 *
 	 * @param message input message
-	 * @return instance of {@link FunctionRoutingResult} containing the result of the routing computation
+	 * @return instance of {@link String} containing the result of the routing computation
 	 */
 	default String routingResult(Message<?> message) {
 		return (String) message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION);


### PR DESCRIPTION
This pull request corrects two grammatical errors identified in the project documentation:

1. **Documentation**: The documentation inaccurately states that `MessageRoutingCallback` expects a `FunctionRoutingResult` instead of a `String`
2. **JavaDoc**: Within the same interface, the JavaDoc incorrectly mentions that it is expected a `FunctionRoutingResult` instead of a `String` type.