### PR TITLE
Copy configuration from context ObjectMapper

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
@@ -214,8 +214,14 @@ public class ContextFunctionCatalogAutoConfiguration {
 		}
 
 		private JsonMapper jackson(ApplicationContext context) {
-			ObjectMapper mapper = new ObjectMapper();
-			mapper.registerModule(new JavaTimeModule());
+			ObjectMapper mapper;
+			try {
+				mapper = context.getBean(ObjectMapper.class);
+			}
+			catch (Exception e) {
+				mapper = new ObjectMapper();
+			}
+            mapper.registerModule(new JavaTimeModule());
 			mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 			mapper.configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true);
 			return new JacksonMapper(mapper);

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
@@ -216,12 +216,12 @@ public class ContextFunctionCatalogAutoConfiguration {
 		private JsonMapper jackson(ApplicationContext context) {
 			ObjectMapper mapper;
 			try {
-				mapper = context.getBean(ObjectMapper.class);
+				mapper = context.getBean(ObjectMapper.class).copy();
 			}
 			catch (Exception e) {
 				mapper = new ObjectMapper();
 			}
-            mapper.registerModule(new JavaTimeModule());
+			mapper.registerModule(new JavaTimeModule());
 			mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 			mapper.configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true);
 			return new JacksonMapper(mapper);


### PR DESCRIPTION
This PR reverts the change from 8b66fd2 that caused some regressions and tries to solve the problem in a different way: it just copies the original ObjectMapper before modifying it.

This should solve #1158 and #1159.