### PR TITLE
Remove org.json:json dependency

### DIFF
--- a/spring-cloud-function-context/pom.xml
+++ b/spring-cloud-function-context/pom.xml
@@ -57,11 +57,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 		    <groupId>com.fasterxml.jackson.datatype</groupId>
 		    <artifactId>jackson-datatype-jsr310</artifactId>
 		</dependency>

--- a/spring-cloud-function-context/pom.xml
+++ b/spring-cloud-function-context/pom.xml
@@ -64,12 +64,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<optional>true</optional>
-			<exclusions>
-				<exclusion>
-					<groupId>com.vaadin.external.google</groupId>
-					<artifactId>android-json</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
@@ -111,12 +105,6 @@
 			<artifactId>cloudevents-spring</artifactId>
 			<version>2.2.0</version>
 			<optional>true</optional>
-		</dependency>
-		
-		<dependency>
-		    <groupId>org.json</groupId>
-		    <artifactId>json</artifactId>
-		    <version>20240303</version>
 		</dependency>
 
 		<!-- Actuator -->

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JsonMapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JsonMapper.java
@@ -24,13 +24,14 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import org.springframework.cloud.function.context.catalog.FunctionTypeUtils;
 
@@ -137,33 +138,33 @@ public abstract class JsonMapper {
 				&& !value.getClass().getPackage().getName().startsWith("reactor.util.function")) {
 			return true;
 		}
-		if (value instanceof byte[]) {
-			value = new String((byte[]) value, StandardCharsets.UTF_8);
+		if (value instanceof byte[] byteValue) {
+			value = new String(byteValue, StandardCharsets.UTF_8);
 		}
-		if (value instanceof String) {
+		if (value instanceof String stringValue) {
 			try {
-				new JSONArray((String) value);
+				JsonNode node = mapper.readTree(stringValue);
+				return node instanceof ArrayNode;
 			}
-			catch (JSONException e) {
+			catch (JsonProcessingException e) {
 				return false;
 			}
-			return true;
 		}
 		return false;
 	}
 
 	public static boolean isJsonStringRepresentsMap(Object value) {
-		if (value instanceof byte[]) {
-			value = new String((byte[]) value, StandardCharsets.UTF_8);
+		if (value instanceof byte[] byteValue) {
+			value = new String(byteValue, StandardCharsets.UTF_8);
 		}
-		if (value instanceof String) {
+		if (value instanceof String stringValue) {
 			try {
-				new JSONObject(value);
+				JsonNode node = mapper.readTree(stringValue);
+				return node instanceof ObjectNode;
 			}
-			catch (JSONException e) {
+			catch (JsonProcessingException e) {
 				return false;
 			}
-			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
Replace the usage of `org.json:json` with Jackson's `ObjectMapper`, removing the dependency conflict reported in #1156 .

I'm still doubtful wether this is the correct way to go - just because an input is valid JSON, does not mean it should necessarily be interpreted as such. However this does remove the additional dependency, thus resolving the conflict and should retain the existing behaviour.

I tried to modify `isJsonString` in a similar manner (`instanceof TextNode`) which caused multiple tests to fail, so I kept it as is.