### PR TITLE
Change "synchronized" to reentrant lock for virtual-threads

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessAsyncContext.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessAsyncContext.java
@@ -57,7 +57,7 @@ public class ServerlessAsyncContext implements AsyncContext {
 
 	private final List<Runnable> dispatchHandlers = new ArrayList<>();
 
-	private static final ReentrantLock globalLock = new ReentrantLock();
+	private final ReentrantLock globalLock = new ReentrantLock();
 
 
 	public ServerlessAsyncContext(ServletRequest request, @Nullable ServletResponse response) {
@@ -69,7 +69,7 @@ public class ServerlessAsyncContext implements AsyncContext {
 	public void addDispatchHandler(Runnable handler) {
 		Assert.notNull(handler, "Dispatch handler must not be null");
 		try {
-			globalLock.lock();
+			this.globalLock.lock();
 			if (this.dispatchedPath == null) {
 				this.dispatchHandlers.add(handler);
 			}
@@ -78,7 +78,7 @@ public class ServerlessAsyncContext implements AsyncContext {
 			}
 		}
 		finally {
-			globalLock.unlock();
+			this.globalLock.unlock();
 		}
 	}
 
@@ -111,12 +111,12 @@ public class ServerlessAsyncContext implements AsyncContext {
 	@Override
 	public void dispatch(@Nullable ServletContext context, String path) {
 		try {
-			globalLock.lock();
+			this.globalLock.lock();
 			this.dispatchedPath = path;
 			this.dispatchHandlers.forEach(Runnable::run);
 		}
 		finally {
-			globalLock.unlock();
+			this.globalLock.unlock();
 		}
 	}
 


### PR DESCRIPTION
**initialize** method in **AzureWebProxyInvoker** class
**initialize** method in **AzureFunctionInstanceInjector** class
**initialize** method in **FunctionInvoker** class
**addDispatchHandler** and  **dispatch** methods in **ServerlessAsyncContext** class
**INSTANCE** method in **JsonMasker** class
**memoize** method in **FunctionLookupHelper** class

were made thread-safe using **ReentrantLock**. This commit ensures that the method is friendly for virtual threads to avoid blocking and pinning. The lock is acquired at the beginning of the method and released in a finally block to ensure it is always released, even if an exception occurs.