### PR TITLE
implement ServerlessServletContext.getResource and ServerlessServletContext.getResourceAsStream

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessServletContext.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessServletContext.java
@@ -125,12 +125,12 @@ public class ServerlessServletContext implements ServletContext {
 
 	@Override
 	public URL getResource(String path) throws MalformedURLException {
-		throw new UnsupportedOperationException("This ServletContext does not represent a running web container");
+		return ServerlessServletContext.class.getResource(path);
 	}
 
 	@Override
 	public InputStream getResourceAsStream(String path) {
-		return null;
+		return ServerlessServletContext.class.getResourceAsStream(path);
 	}
 
 	@Override


### PR DESCRIPTION
After upgrading to Spring Framework 6.2.0 along with Spring Boot 3.4.0 I saw tests failing:
```
Caused by: java.lang.UnsupportedOperationException: This ServletContext does not represent a running web container
        at org.springframework.cloud.function.serverless.web.ServerlessServletContext.getResource(ServerlessServletContext.java:117)
        at org.springframework.web.context.support.ServletContextResource.getURL(ServletContextResource.java:177)
        at org.springframework.web.servlet.resource.ResourceHandlerUtils.assertResourceLocation(ResourceHandlerUtils.java:67)
        at org.springframework.web.servlet.resource.ResourceHttpRequestHandler.setLocations(ResourceHttpRequestHandler.java:184)
        at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration.getRequestHandler(ResourceHandlerRegistration.java:239)
        at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry.getRequestHandler(ResourceHandlerRegistry.java:178)
        at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry.getHandlerMapping(ResourceHandlerRegistry.java:168)
        at org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport.resourceHandlerMapping(WebMvcConfigurationSupport.java:601)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:171)
        ... 46 more

```