### PR TITLE
Fix `FunctionTypeUtils` for `FactoryBean`

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Oleg Zhurakousky
  * @author Andrey Shlykov
+ * @author Artem Bilan
  *
  * @since 3.0
  */
@@ -442,6 +443,12 @@ public final class FunctionTypeUtils {
 				if (StringUtils.hasText(beanDefinitionName)) {
 					type = FunctionContextUtils.findType(applicationContext.getBeanFactory(), beanDefinitionName);
 				}
+			}
+		}
+		else if (type instanceof ParameterizedType) {
+			ResolvableType resolvableType = ResolvableType.forType(type);
+			if (FactoryBean.class.isAssignableFrom(resolvableType.toClass())) {
+				return resolvableType.getGeneric(0).getType();
 			}
 		}
 		return type;

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import reactor.util.function.Tuple2;
 import reactor.util.function.Tuple3;
 import reactor.util.function.Tuples;
 
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -83,6 +84,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  *
  */
 public class BeanFactoryAwareFunctionRegistryTests {
@@ -850,6 +852,14 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	}
 
 	@Test
+	void functionFromFactoryBeanIsProperlyResolved() {
+		FunctionCatalog catalog = configureCatalog();
+		Function<Number, String> numberToStringFactoryBean = catalog.lookup("numberToStringFactoryBean");
+		assertThat(numberToStringFactoryBean).isNotNull();
+		assertThat(numberToStringFactoryBean.apply(1)).isEqualTo("1");
+	}
+
+	@Test
 	// see GH-707
 	public void testConcurrencyOnLookup() throws Exception {
 		AtomicInteger counter = new AtomicInteger();
@@ -1299,6 +1309,23 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		// Perhaps it should not be allowed. Recommend Function<Flux, Mono<Void>>
 		public Consumer<Flux<Person>> reactivePojoConsumer() {
 			return flux -> flux.subscribe(v -> consumerInputRef.set(v));
+		}
+
+		@Bean
+		FactoryBean<Function<Number, String>> numberToStringFactoryBean() {
+			return new FactoryBean<>() {
+
+				@Override
+				public Function<Number, String> getObject() {
+					return Number::toString;
+				}
+
+				@Override
+				public Class<?> getObjectType() {
+					return Function.class;
+				}
+
+			};
 		}
 	}
 


### PR DESCRIPTION
The function bean can be declared as a `FactoryBean`, for example with Spring Integration's `GatewayProxyFactoryBean`. See `LogConsumerConfiguration` in Spring Functions Catalog project.

* Fix `FunctionTypeUtils` to react to the `ParameterizedType` and check its assignments against `Factory` bean.
Then resolves its generic to the proper target function type.
* Add `BeanFactoryAwareFunctionRegistryTests.functionFromFactoryBeanIsProperlyResolved()` to verify that `FactoryBean<Function<?, ?>>` is resolved properly