### PR TITLE
Remove unused println statements from test methods

### DIFF
--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpPostIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpPostIntegrationTests.java
@@ -483,7 +483,6 @@ public class HttpPostIntegrationTests {
 		@Bean
 		public Consumer<Flux<String>> updates() {
 			return flux -> flux.subscribe(value -> {
-				System.out.println();
 					this.list.add(value);
 				});
 		}

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerTests.java
@@ -126,7 +126,6 @@ public class FunctionEndpointInitializerTests {
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
 		ResponseEntity<String> response = testRestTemplate
 				.getForEntity(new URI("http://localhost:" + port + "/reverse/stressed"), String.class);
-		System.out.println();
 		assertThat(response.getBody()).isEqualTo("desserts");
 	}
 


### PR DESCRIPTION
## Description
Remove unnecessary System.out.println() statements from test methods that don't contribute to test functionality.



