### PR TITLE
feat: add reactor publisher support for spring-cloud-function-adapter-gcp

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerBackgroundTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerBackgroundTests.java
@@ -22,6 +22,10 @@ import java.util.function.Supplier;
 
 import com.github.blindpirate.extensions.CaptureSystemOutput;
 import com.google.gson.Gson;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +59,18 @@ public class FunctionInvokerBackgroundTests {
 	@Test
 	public void testJsonInputFunction_Background(CaptureSystemOutput.OutputCapture outputCapture) {
 		testBackgroundFunction(outputCapture, JsonInputFunction.class, new IncomingRequest("hello"),
+				"Thank you for sending the message: hello", null, null);
+	}
+
+	@Test
+	public void testJsonInputFunction_BackgroundMono(CaptureSystemOutput.OutputCapture outputCapture) {
+		testBackgroundFunction(outputCapture, JsonInputFunctionMono.class, new IncomingRequest("hello"),
+				"Thank you for sending the message: hello", null, null);
+	}
+
+	@Test
+	public void testJsonInputFunction_BackgroundFlux(CaptureSystemOutput.OutputCapture outputCapture) {
+		testBackgroundFunction(outputCapture, JsonInputFunctionFlux.class, new IncomingRequest("hello"),
 				"Thank you for sending the message: hello", null, null);
 	}
 
@@ -145,6 +161,28 @@ public class FunctionInvokerBackgroundTests {
 		@Bean
 		public Function<IncomingRequest, String> function() {
 			return (in) -> "Thank you for sending the message: " + in.message;
+		}
+
+	}
+
+	@Configuration
+	@Import({ ContextFunctionCatalogAutoConfiguration.class })
+	protected static class JsonInputFunctionMono {
+
+		@Bean
+		public Function<Mono<IncomingRequest>, Mono<String>> function() {
+			return (in) -> in.map(o -> "Thank you for sending the message: " + o.message);
+		}
+
+	}
+
+	@Configuration
+	@Import({ ContextFunctionCatalogAutoConfiguration.class })
+	protected static class JsonInputFunctionFlux {
+
+		@Bean
+		public Function<Flux<IncomingRequest>, Flux<String>> function() {
+			return (in) -> in.map(o -> "Thank you for sending the message: " + o.message);
 		}
 
 	}


### PR DESCRIPTION
related: https://github.com/spring-cloud/spring-cloud-function/issues/1259

I've been trying to use reactive programming in functional interfaces, so I've added in FunctionInvoker some methods to validate if result object is reactor's publisher before cast it in Message.

For more information, I copied some code from https://github.com/spring-cloud/spring-cloud-function/blob/main/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java

If this PR is approved, everyone can use functions http and background with reactive programming style like this:

```java
class JsonInputFunctionFlux {

        @Bean
        public Function<Flux<String>, Flux<String>> function() {
	        return (in) -> in.map(word -> word + "!!!");
        }

}
``` 

Thank you very much for all the support and I hope this feature will be very useful.