### PR TITLE
GH-1285 Change log level to debug for failed function lookup

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -300,8 +300,10 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 		for (String functionName : functionNames) {
 			FunctionInvocationWrapper function = this.findFunctionInFunctionRegistrations(functionName);
 			if (function == null) {
-				logger.warn("Failed to locate function '" + functionName + "' for function definition '"
+				if (logger.isDebugEnabled()) {
+					logger.debug("Failed to locate function '" + functionName + "' for function definition '"
 						+ functionDefinition + "'. Returning null.");
+				}
 				return null;
 			}
 			else {


### PR DESCRIPTION
Resolves #1285
Related #1265

The warn log was introduced in the latest release for a failed function lookup.
If I understood correctly, this is being emitted on every first call to the function when a first lookup will happen, which can significantly pollute the logs in production environments.
Since this message seems not to indicate an error or unexpected behaviour, but rather reflects a normal and expected code path, debug can be a more appropriate log level.

This is my first contribution to the project - please feel free to disregard if you believe this change is not aligned with the logging strategy.