### PR TITLE
GH-1327 Fix wrapped flag not reset on exception in FunctionAroundWrapper

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionAroundWrapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionAroundWrapper.java
@@ -41,9 +41,12 @@ public abstract class FunctionAroundWrapper {
 		boolean functionalTracingEnabled = !StringUtils.hasText(functionalTracingEnabledStr)
 				|| Boolean.parseBoolean(functionalTracingEnabledStr);
 		if (functionalTracingEnabled && !(input instanceof Publisher) && input instanceof Message && !FunctionTypeUtils.isCollectionOfMessage(targetFunction.getOutputType())) {
-			Object result = this.doApply(input, targetFunction);
-			targetFunction.wrapped = false;
-			return result;
+			try {
+				return this.doApply(input, targetFunction);
+			}
+			finally {
+				targetFunction.wrapped = false;
+			}
 		}
 		else {
 			return targetFunction.apply(input);

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
@@ -719,6 +719,33 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
+	public void testAroundWrapperAppliedOnEveryInvocation() {
+		FunctionCatalog catalog = this.configureCatalog(AroundWrapperExceptionResetConfiguration.class);
+		FunctionInvocationWrapper f = catalog.lookup("uppercase");
+		AtomicInteger wrapperCallCount = (AtomicInteger) this.context.getBean("wrapperCallCount");
+
+		// successful invocation
+		Message result = (Message) f.apply(MessageBuilder.withPayload("hello").build());
+		assertThat(result.getPayload()).isEqualTo("HELLO");
+		assertThat(wrapperCallCount.get()).isEqualTo(1);
+
+		// failed invocation
+		try {
+			f.apply(MessageBuilder.withPayload("exception").build());
+		}
+		catch (RuntimeException e) {
+			// expected
+		}
+		assertThat(wrapperCallCount.get()).isEqualTo(2);
+
+		// subsequent invocation must still go through the wrapper
+		result = (Message) f.apply(MessageBuilder.withPayload("world").build());
+		assertThat(result.getPayload()).isEqualTo("WORLD");
+		assertThat(wrapperCallCount.get()).isEqualTo(3);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
 	public void testEachElementInFluxIsProcessed() {
 		FunctionCatalog catalog = this.configureCatalog(SampleFunctionConfiguration.class);
 		Function f = catalog.lookup("uppercasePerson");
@@ -1614,6 +1641,37 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		@Bean
 		public Function<Message<?>, Message<?>> myFunction() {
 			return msg -> msg;
+		}
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	protected static class AroundWrapperExceptionResetConfiguration {
+
+		@Bean
+		public Function<Message<String>, Message<String>> uppercase() {
+			return v -> {
+				if ("exception".equals(v.getPayload())) {
+					throw new RuntimeException("Expected exception");
+				}
+				return MessageBuilder.withPayload(v.getPayload().toUpperCase(Locale.ROOT)).copyHeaders(v.getHeaders()).build();
+			};
+		}
+
+		@Bean
+		public AtomicInteger wrapperCallCount() {
+			return new AtomicInteger();
+		}
+
+		@Bean
+		public FunctionAroundWrapper wrapper(AtomicInteger wrapperCallCount) {
+			return new FunctionAroundWrapper() {
+				@Override
+				protected Object doApply(Object input, FunctionInvocationWrapper targetFunction) {
+					wrapperCallCount.incrementAndGet();
+					return targetFunction.apply(input);
+				}
+			};
 		}
 	}
 }


### PR DESCRIPTION
Ensure the wrapped flag on FunctionInvocationWrapper is reset in a finally block so that an exception from doApply does not leave it stuck at true, which would cause subsequent invocations to bypass the FunctionAroundWrapper (breaking tracing context propagation).