### PR TITLE
GH-1391 Add single function fallback opt-out

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionProperties.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionProperties.java
@@ -82,6 +82,11 @@ public class FunctionProperties implements EnvironmentAware, ApplicationContextA
 	 */
 	private final List<String> ineligibleDefinitions;
 
+	/**
+	 * Whether a single eligible function can be looked up when the requested name is absent.
+	 */
+	private boolean singleFunctionFallbackEnabled = true;
+
 	private Map<String, FunctionConfigurationProperties> configuration;
 
 	private String expectedContentType;
@@ -194,6 +199,14 @@ public class FunctionProperties implements EnvironmentAware, ApplicationContextA
 
 	public void setIneligibleDefinitions(List<String> definitions) {
 		this.ineligibleDefinitions.addAll(definitions);
+	}
+
+	public boolean isSingleFunctionFallbackEnabled() {
+		return this.singleFunctionFallbackEnabled;
+	}
+
+	public void setSingleFunctionFallbackEnabled(boolean singleFunctionFallbackEnabled) {
+		this.singleFunctionFallbackEnabled = singleFunctionFallbackEnabled;
 	}
 
 	public static class FunctionConfigurationProperties {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -266,7 +266,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 				: System.getProperty(FunctionProperties.FUNCTION_DEFINITION, "");
 
 		Set<String> names = this.getNames(null);
-		if (!names.contains(functionDefinition)) {
+		if (this.isSingleFunctionFallbackEnabled() && !names.contains(functionDefinition)) {
 			List<String> eligibleFunction = names.stream()
 					.filter(name -> !RoutingFunction.FUNCTION_NAME.equals(name))
 					.filter(name -> !RoutingFunction.DEFAULT_ROUTE_HANDLER.equals(name))
@@ -279,6 +279,10 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			}
 		}
 		return functionDefinition;
+	}
+
+	private boolean isSingleFunctionFallbackEnabled() {
+		return this.functionProperties == null || this.functionProperties.isSingleFunctionFallbackEnabled();
 	}
 
 	/*

--- a/spring-cloud-function-context/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-function-context/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -15,6 +15,12 @@
 			"defaultValue": ""
 		},
 		{
+			"name": "spring.cloud.function.single-function-fallback-enabled",
+			"type": "java.lang.Boolean",
+			"description": "Whether a single eligible function can be looked up when the requested name is absent.",
+			"defaultValue": true
+		},
+		{
 			"name": "spring.cloud.function.routing.enabled",
 			"type": "java.lang.Boolean",
 			"description": "Enables RoutingFunction which delegates incoming request to a function named via function.name header",

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
@@ -98,9 +98,15 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	}
 
 	private FunctionCatalog configureCatalog(Class<?>... configClass) {
-		this.context = new SpringApplicationBuilder(configClass)
-				.run("--logging.level.org.springframework.cloud.function=DEBUG",
-						"--spring.main.lazy-initialization=true");
+		return this.configureCatalogWithProperties(new String[0], configClass);
+	}
+
+	private FunctionCatalog configureCatalogWithProperties(String[] properties, Class<?>... configClass) {
+		List<String> args = new ArrayList<>();
+		args.add("--logging.level.org.springframework.cloud.function=DEBUG");
+		args.add("--spring.main.lazy-initialization=true");
+		args.addAll(Arrays.asList(properties));
+		this.context = new SpringApplicationBuilder(configClass).run(args.toArray(new String[0]));
 		FunctionCatalog catalog = context.getBean(FunctionCatalog.class);
 		return catalog;
 	}
@@ -302,6 +308,23 @@ public class BeanFactoryAwareFunctionRegistryTests {
 //		field.setAccessible(true);
 //		assertThat(((boolean) field.get(function))).isTrue();
 		assertThat(((FunctionInvocationWrapper) function).isComposed()).isTrue();
+	}
+
+	@Test
+	public void testSingleFunctionFallbackIsEnabledByDefault() {
+		FunctionCatalog catalog = this.configureCatalog(InputHeaderPropagationConfiguration.class);
+
+		assertThat((Object) catalog.lookup("missingFunction")).isNotNull();
+	}
+
+	@Test
+	public void testSingleFunctionFallbackCanBeDisabled() {
+		FunctionCatalog catalog = this.configureCatalogWithProperties(
+				new String[] { "--spring.cloud.function.single-function-fallback-enabled=false" },
+				InputHeaderPropagationConfiguration.class);
+
+		assertThat((Object) catalog.lookup("missingFunction")).isNull();
+		assertThat((Object) catalog.lookup("uppercase")).isNotNull();
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
## Summary

- Add `spring.cloud.function.single-function-fallback-enabled`, defaulting to `true`, so existing single-function lookup behavior remains unchanged.
- When disabled, an unmatched `FunctionCatalog.lookup("<name>")` no longer normalizes to the only registered function.
- Update configuration metadata and add regression coverage for both default and disabled lookup behavior.

Closes #1391

## Testing

- `./mvnw -pl spring-cloud-function-context '-Dtest=BeanFactoryAwareFunctionRegistryTests#testSingleFunctionFallback*' test`
- `./mvnw -pl spring-cloud-function-context '-Dtest=BeanFactoryAwareFunctionRegistryTests' test`
- `./mvnw -pl spring-cloud-function-context test`