### PR TITLE
Ignore release-train workflow dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
     schedule:
       interval: "weekly"
   - package-ecosystem: maven


### PR DESCRIPTION
Dependabot GitHub Actions updates are currently scanning release-train workflow files that should not receive automated dependency bumps. This change avoids noisy or undesired updates from those workflows.

## What changed
- Added `exclude-paths` to the `github-actions` entry in `.github/dependabot.yaml`
- Excluded:
  - `.github/workflows/release-train-test.yml`
  - `.github/workflows/release-train-build.yml`

This keeps GitHub Actions dependency update PRs focused on the workflows we want Dependabot to manage.