### PR TITLE
fix(gcp): register nested URL protocol handler in GcfJarLauncher

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncher.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncher.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.function.adapter.gcp;
 
+import java.net.URL;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
 import com.google.cloud.functions.Context;
 import com.google.cloud.functions.HttpFunction;
 import com.google.cloud.functions.HttpRequest;
@@ -23,6 +27,8 @@ import com.google.cloud.functions.HttpResponse;
 import com.google.cloud.functions.RawBackgroundFunction;
 
 import org.springframework.boot.loader.launch.JarLauncher;
+import org.springframework.boot.loader.net.protocol.Handlers;
+import org.springframework.boot.loader.net.protocol.nested.Handler;
 
 /**
  * The launcher class written at the top-level of the output JAR to be deployed to
@@ -30,21 +36,44 @@ import org.springframework.boot.loader.launch.JarLauncher;
  *
  * @author Ray Tsang
  * @author Daniel Zou
+ * @author Roman Akentev
  */
 public class GcfJarLauncher extends JarLauncher implements HttpFunction, RawBackgroundFunction {
+
+	private static final URLStreamHandlerFactory NESTED_URL_STREAM_HANDLER_FACTORY = new NestedUrlStreamHandlerFactory();
 
 	private final ClassLoader loader;
 
 	private final Object delegate;
 
 	public GcfJarLauncher() throws Exception {
-		//JarFile.registerUrlProtocolHandler();
+		Handlers.register();
+		registerNestedUrlStreamHandlerFactory();
 
 		this.loader = createClassLoader(getClassPathUrls());
 
 		Class<?> clazz = this.loader
 			.loadClass("org.springframework.cloud.function.adapter.gcp.FunctionInvoker");
 		this.delegate = clazz.getConstructor().newInstance();
+	}
+
+	/**
+	 * Install a {@link URLStreamHandlerFactory} that provides the {@code nested:}
+	 * handler directly, without relying on the {@code java.protocol.handler.pkgs}
+	 * property. That property is only consulted by the JVM through the bootstrap
+	 * and system classloaders, so it cannot find the handler when the loader
+	 * classes are only visible to the classloader of the deployed fat JAR (e.g.
+	 * when the Google Cloud Functions framework loads the JAR in a child
+	 * {@code URLClassLoader}).
+	 */
+	private void registerNestedUrlStreamHandlerFactory() {
+		try {
+			URL.setURLStreamHandlerFactory(NESTED_URL_STREAM_HANDLER_FACTORY);
+		}
+		catch (Error error) {
+			// A factory is already installed. Handlers.register() above may still be
+			// sufficient when the loader classes are on the system classpath.
+		}
 	}
 
 	@Override
@@ -58,5 +87,15 @@ public class GcfJarLauncher extends JarLauncher implements HttpFunction, RawBack
 		Thread.currentThread().setContextClassLoader(this.loader);
 		((RawBackgroundFunction) delegate).accept(json, context);
 	}
+
+	private static final class NestedUrlStreamHandlerFactory implements URLStreamHandlerFactory {
+
+		@Override
+		public URLStreamHandler createURLStreamHandler(String protocol) {
+			return ("nested".equals(protocol)) ? new Handler() : null;
+		}
+
+	}
+
 }
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncher.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncher.java
@@ -23,6 +23,7 @@ import com.google.cloud.functions.HttpResponse;
 import com.google.cloud.functions.RawBackgroundFunction;
 
 import org.springframework.boot.loader.launch.JarLauncher;
+import org.springframework.boot.loader.net.protocol.Handlers;
 
 /**
  * The launcher class written at the top-level of the output JAR to be deployed to
@@ -30,6 +31,7 @@ import org.springframework.boot.loader.launch.JarLauncher;
  *
  * @author Ray Tsang
  * @author Daniel Zou
+ * @author Roman Akentev
  */
 public class GcfJarLauncher extends JarLauncher implements HttpFunction, RawBackgroundFunction {
 
@@ -38,7 +40,7 @@ public class GcfJarLauncher extends JarLauncher implements HttpFunction, RawBack
 	private final Object delegate;
 
 	public GcfJarLauncher() throws Exception {
-		//JarFile.registerUrlProtocolHandler();
+		Handlers.register();
 
 		this.loader = createClassLoader(getClassPathUrls());
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncherTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncherTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.adapter.gcp;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests verifying that {@link GcfJarLauncher} registers the {@code nested:}
+ * URL protocol handler via {@code Handlers.register()} before creating its
+ * classloader. Without this, {@code JarUrlClassLoader} would fail with
+ * {@code java.net.MalformedURLException: unknown protocol: nested} when
+ * trying to resolve JARs inside the repackaged archive (GH-1336).
+ * <p>
+ * The test forks a subprocess to avoid interference from other Spring Boot
+ * classes that may have already registered the protocol in the current JVM.
+ *
+ * @author Roman Akentev
+ * @see <a href="https://github.com/spring-cloud/spring-cloud-function/issues/1336">GH-1336</a>
+ */
+public class GcfJarLauncherTests {
+
+	public static final String PROTOCOL_ALREADY_REGISTERED = "PROTOCOL_ALREADY_REGISTERED";
+
+	public static final String PROTOCOL_NOT_REGISTERED = "PROTOCOL_NOT_REGISTERED";
+
+	public static final String GCF_JAR_LAUNCHER_SUCCEEDED = "GCF_JAR_LAUNCHER_SUCCEEDED";
+
+	public static final String GCF_JAR_LAUNCHER_FAILED = "GCF_JAR_LAUNCHER_FAILED";
+
+	public static final String PROTOCOL_NOW_REGISTERED = "PROTOCOL_NOW_REGISTERED";
+
+	public static final String PROTOCOL_STILL_NOT_REGISTERED = "PROTOCOL_STILL_NOT_REGISTERED";
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	public void nestedProtocolIsRegisteredByGcfJarLauncher() throws Exception {
+		String javaHome = System.getProperty("java.home");
+		String classPath = System.getProperty("java.class.path");
+
+		Path sourceFile = tempDir.resolve("ProtocolCheck.java");
+		try (InputStream in = Objects.requireNonNull(
+				getClass().getResourceAsStream("/ProtocolCheck.java"),
+				"Resource /ProtocolCheck.java not found")) {
+			Files.copy(in, sourceFile, StandardCopyOption.REPLACE_EXISTING);
+		}
+
+		Process compile = new ProcessBuilder(
+				Path.of(javaHome, "bin", "javac").toString(),
+				"-cp", classPath,
+				"-d", tempDir.toString(),
+				sourceFile.toString())
+				.redirectErrorStream(true)
+				.start();
+		String compileOutput = new BufferedReader(
+				new InputStreamReader(compile.getInputStream()))
+				.lines().collect(Collectors.joining("\n"));
+		int compileExit = compile.waitFor();
+		assertThat(compileExit)
+				.as("compilation failed:\n" + compileOutput)
+				.isZero();
+
+		Process run = new ProcessBuilder(
+				Path.of(javaHome, "bin", "java").toString(),
+				"-cp", classPath + File.pathSeparatorChar + tempDir,
+				"ProtocolCheck")
+				.redirectErrorStream(true)
+				.start();
+		String output = new BufferedReader(new InputStreamReader(run.getInputStream()))
+				.lines().collect(Collectors.joining("\n"));
+		int exitCode = run.waitFor();
+
+		assertThat(exitCode).as("ProtocolCheck exit code").isZero();
+		assertThat(output).as("ProtocolCheck output")
+			.contains(PROTOCOL_NOT_REGISTERED + ": unknown protocol: nested")
+			.contains(PROTOCOL_NOW_REGISTERED);
+	}
+
+}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncherTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/GcfJarLauncherTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.adapter.gcp;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Enumeration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import com.google.cloud.functions.HttpFunction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.boot.loader.launch.Launcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests verifying that {@link GcfJarLauncher} registers the {@code nested:}
+ * URL protocol handler before creating its classloader (GH-1336).
+ * <p>
+ * The test builds a Spring Boot fat JAR, then forks a subprocess that loads
+ * {@code GcfJarLauncher} from that JAR through a child {@code URLClassLoader}
+ * - mirroring how the Google Cloud Functions framework loads the deployed
+ * function JAR. In that setup spring-boot-loader is only visible inside the
+ * fat JAR, so the launcher must install a {@code nested:} handler that the
+ * JVM can resolve without the loader classes being on the system classpath.
+ * The subprocess is also checked to fail on the {@code nested:} protocol
+ * before the launcher is constructed, proving the handler is not already
+ * registered by anything else.
+ *
+ * @author Roman Akentev
+ * @see <a href="https://github.com/spring-cloud/spring-cloud-function/issues/1336">GH-1336</a>
+ */
+public class GcfJarLauncherTests {
+
+	public static final String PROTOCOL_ALREADY_REGISTERED = "PROTOCOL_ALREADY_REGISTERED";
+
+	public static final String PROTOCOL_NOT_REGISTERED = "PROTOCOL_NOT_REGISTERED";
+
+	public static final String GCF_JAR_LAUNCHER_SUCCEEDED = "GCF_JAR_LAUNCHER_SUCCEEDED";
+
+	public static final String GCF_JAR_LAUNCHER_FAILED = "GCF_JAR_LAUNCHER_FAILED";
+
+	public static final String PROTOCOL_NOW_REGISTERED = "PROTOCOL_NOW_REGISTERED";
+
+	public static final String PROTOCOL_STILL_NOT_REGISTERED = "PROTOCOL_STILL_NOT_REGISTERED";
+
+	private static final String GCF_LAUNCHER_CLASS_NAME = "org.springframework.cloud.function.adapter.gcp.GcfJarLauncher";
+
+	private static final String FUNCTION_INVOKER_CLASS_NAME = "org.springframework.cloud.function.adapter.gcp.FunctionInvoker";
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	public void nestedProtocolIsRegisteredByGcfJarLauncher() throws Exception {
+		String javaHome = System.getProperty("java.home");
+		Path classesDir = tempDir.resolve("classes");
+		compile(javaHome, classesDir);
+
+		Path functionJar = createFunctionJar(classesDir);
+		Path frameworkApiJar = codeSource(HttpFunction.class);
+
+		Process process = new ProcessBuilder(Path.of(javaHome, "bin", "java").toString(), "-cp",
+				String.join(File.pathSeparator, functionJar.toString(), frameworkApiJar.toString(),
+						classesDir.toString()),
+				"ProtocolCheck", functionJar.toString())
+			.redirectErrorStream(true)
+			.start();
+		boolean finished = process.waitFor(2, TimeUnit.MINUTES);
+		String output = new BufferedReader(new InputStreamReader(process.getInputStream())).lines()
+			.collect(Collectors.joining("\n"));
+		if (!finished) {
+			process.destroyForcibly();
+		}
+
+		assertThat(finished).as("ProtocolCheck timed out:\n" + output).isTrue();
+		assertThat(process.exitValue()).as("ProtocolCheck exit code:\n" + output).isZero();
+		assertThat(output).as("ProtocolCheck output")
+			.contains(PROTOCOL_NOT_REGISTERED + ": unknown protocol: nested")
+			.contains(GCF_JAR_LAUNCHER_SUCCEEDED)
+			.contains(PROTOCOL_NOW_REGISTERED);
+	}
+
+	private void compile(String javaHome, Path classesDir) throws Exception {
+		Files.createDirectories(classesDir);
+		Path protocolCheck = tempDir.resolve("ProtocolCheck.java");
+		writeResource(protocolCheck, "/ProtocolCheck.java");
+		Path stubInvoker = tempDir.resolve("FunctionInvoker.java");
+		writeResource(stubInvoker, "/StubFunctionInvoker.java");
+		Process compile = new ProcessBuilder(Path.of(javaHome, "bin", "javac").toString(), "-d",
+				classesDir.toString(), protocolCheck.toString(), stubInvoker.toString())
+			.redirectErrorStream(true)
+			.start();
+		String compileOutput = new BufferedReader(new InputStreamReader(compile.getInputStream())).lines()
+			.collect(Collectors.joining("\n"));
+		boolean finished = compile.waitFor(1, TimeUnit.MINUTES);
+		if (!finished) {
+			compile.destroyForcibly();
+		}
+		assertThat(finished).as("javac timed out").isTrue();
+		assertThat(compile.exitValue()).as("compilation failed:\n" + compileOutput).isZero();
+	}
+
+	private Path createFunctionJar(Path classesDir) throws Exception {
+		Path functionJar = tempDir.resolve("function.jar");
+		try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(functionJar))) {
+			writeEntry(zip, "META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n".getBytes(StandardCharsets.UTF_8));
+			Path loaderJar = codeSource(Launcher.class);
+			try (JarFile loader = new JarFile(loaderJar.toFile())) {
+				Enumeration<JarEntry> entries = loader.entries();
+				while (entries.hasMoreElements()) {
+					JarEntry entry = entries.nextElement();
+					if (!entry.isDirectory() && !entry.getName().startsWith("META-INF/")) {
+						writeEntry(zip, entry.getName(), loader.getInputStream(entry).readAllBytes());
+					}
+				}
+			}
+			writeLauncherClasses(zip);
+			writeEntry(zip, "BOOT-INF/lib/spring-cloud-function-adapter-gcp.jar", nestedAdapterJar(classesDir));
+		}
+		return functionJar;
+	}
+
+	private void writeLauncherClasses(ZipOutputStream zip) throws Exception {
+		Path adapterClasses = codeSource(GcfJarLauncher.class);
+		if (!Files.isDirectory(adapterClasses)) {
+			throw new IllegalStateException("Adapter classes are not on the classpath as a directory: " + adapterClasses);
+		}
+		String launcherPrefix = GCF_LAUNCHER_CLASS_NAME.replace('.', '/');
+		try (Stream<Path> paths = Files.walk(adapterClasses)) {
+			for (Path path : paths.toList()) {
+				if (!Files.isRegularFile(path)) {
+					continue;
+				}
+				String entryName = adapterClasses.relativize(path).toString().replace(File.separatorChar, '/');
+				if (entryName.startsWith(launcherPrefix) && entryName.endsWith(".class")) {
+					writeEntry(zip, entryName, Files.readAllBytes(path));
+				}
+			}
+		}
+	}
+
+	private byte[] nestedAdapterJar(Path classesDir) throws IOException {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+			writeEntry(zip, "META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n".getBytes(StandardCharsets.UTF_8));
+			Path stub = classesDir.resolve(FUNCTION_INVOKER_CLASS_NAME.replace('.', '/') + ".class");
+			writeEntry(zip, FUNCTION_INVOKER_CLASS_NAME.replace('.', '/') + ".class", Files.readAllBytes(stub));
+		}
+		return bytes.toByteArray();
+	}
+
+	private static void writeResource(Path target, String resource) throws IOException {
+		try (InputStream in = Objects.requireNonNull(GcfJarLauncherTests.class.getResourceAsStream(resource),
+				"Resource " + resource + " not found")) {
+			Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	private static Path codeSource(Class<?> type) throws Exception {
+		return Path.of(type.getProtectionDomain().getCodeSource().getLocation().toURI());
+	}
+
+	private static void writeEntry(ZipOutputStream zip, String name, byte[] content) throws IOException {
+		zip.putNextEntry(new ZipEntry(name));
+		zip.write(content);
+		zip.closeEntry();
+	}
+
+}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/resources/ProtocolCheck.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/resources/ProtocolCheck.java
@@ -1,0 +1,54 @@
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Subprocess entry point for {@code GcfJarLauncherTests}. Loads
+ * {@code GcfJarLauncher} from a Spring Boot fat JAR through a child
+ * {@link URLClassLoader}, mirroring how the Google Cloud Functions framework
+ * loads the deployed function JAR, and reports whether the {@code nested:}
+ * URL protocol is registered before and after the launcher is constructed
+ * (GH-1336).
+ */
+public class ProtocolCheck {
+
+	public static void main(String[] args) {
+		File functionJar = new File(args[0]);
+		try {
+			new URL("nested:/dev/null");
+			System.out.println("PROTOCOL_ALREADY_REGISTERED");
+		}
+		catch (MalformedURLException ex) {
+			System.out.println("PROTOCOL_NOT_REGISTERED: " + ex.getMessage());
+		}
+		try (URLClassLoader child = new URLClassLoader(new URL[] { toUrl(functionJar) },
+				ClassLoader.getSystemClassLoader())) {
+			Class<?> launcher = Class.forName("org.springframework.cloud.function.adapter.gcp.GcfJarLauncher",
+					true, child);
+			launcher.getConstructor().newInstance();
+			System.out.println("GCF_JAR_LAUNCHER_SUCCEEDED");
+		}
+		catch (Throwable ex) {
+			System.out.println("GCF_JAR_LAUNCHER_FAILED: " + ex);
+			ex.printStackTrace(System.out);
+		}
+		try {
+			new URL("nested:/dev/null");
+			System.out.println("PROTOCOL_NOW_REGISTERED");
+		}
+		catch (MalformedURLException ex) {
+			System.out.println("PROTOCOL_STILL_NOT_REGISTERED: " + ex.getMessage());
+		}
+	}
+
+	private static URL toUrl(File file) {
+		try {
+			return file.toURI().toURL();
+		}
+		catch (MalformedURLException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/resources/ProtocolCheck.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/resources/ProtocolCheck.java
@@ -1,0 +1,39 @@
+import org.springframework.cloud.function.adapter.gcp.GcfJarLauncher;
+import org.springframework.cloud.function.adapter.gcp.GcfJarLauncherTests;
+
+/**
+ * Subprocess entry point for {@link GcfJarLauncherTests}. Compiled and executed
+ * at runtime to verify that the {@code nested:} protocol handler is registered
+ * after {@code GcfJarLauncher} construction (GH-1336).
+ *
+ * @author Roman Akentev
+ */
+public class ProtocolCheck {
+
+	public static void main(String[] args) throws Exception {
+		try {
+			new java.net.URL("nested:/dev/null");
+			System.out.println(GcfJarLauncherTests.PROTOCOL_ALREADY_REGISTERED);
+		}
+		catch (java.net.MalformedURLException e) {
+			System.out.println(GcfJarLauncherTests.PROTOCOL_NOT_REGISTERED + ": " + e.getMessage());
+		}
+		try {
+			new GcfJarLauncher();
+			System.out.println(GcfJarLauncherTests.GCF_JAR_LAUNCHER_SUCCEEDED);
+		}
+		catch (Exception e) {
+			System.out.println(GcfJarLauncherTests.GCF_JAR_LAUNCHER_FAILED + ": "
+					+ e.getClass().getName() + ": " + e.getMessage());
+			e.printStackTrace(System.out);
+		}
+		try {
+			new java.net.URL("nested:/dev/null");
+			System.out.println(GcfJarLauncherTests.PROTOCOL_NOW_REGISTERED);
+		}
+		catch (java.net.MalformedURLException e) {
+			System.out.println(GcfJarLauncherTests.PROTOCOL_STILL_NOT_REGISTERED + ": " + e.getMessage());
+		}
+	}
+
+}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/resources/StubFunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/resources/StubFunctionInvoker.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.function.adapter.gcp;
+
+/**
+ * Minimal stand-in for the real {@code FunctionInvoker} used by
+ * {@code GcfJarLauncherTests}. The real class would bootstrap the entire
+ * Spring application in its constructor, which is not needed to verify that
+ * {@code GcfJarLauncher} can load its delegate from a nested JAR.
+ */
+public class FunctionInvoker {
+
+	public FunctionInvoker() {
+	}
+
+}


### PR DESCRIPTION
hi, @olegz!

I decided to try and fix this issue due to popular demand.

GcfJarLauncher's constructor bypasses Launcher.launch() and creates a LaunchedClassLoader directly, so it must register the nested: URL protocol handler itself. The tricky part is that the functions-framework does not load the function JAR on the system classpath - it loads it in a child URLClassLoader - and the JVM resolves java.protocol.handler.pkgs handlers only through the bootstrap/system classloaders. As a result, Handlers.register() alone still leaves the launcher with java.net.MalformedURLException: unknown protocol: nested (reproduced on a real Boot 4.1.0 function JAR, exactly as in gh-1336).

What I did:

- The constructor now installs a URLStreamHandlerFactory that provides the nested.Handler instance directly, so the handler no longer has to be visible to the system classloader. Handlers.register() is kept as a fallback for the case where some other code has already installed a factory.
- Reworked the test to reproduce the real deployment topology: it builds a Spring Boot fat JAR, forks a JVM that loads GcfJarLauncher from that JAR through a child URLClassLoader (spring-boot-loader is NOT on the system classpath), and asserts that the launcher actually constructs (GCF_JAR_LAUNCHER_SUCCEEDED), not just that the protocol property is set. The test fails with the gh-1336 stack trace on the previous version of this PR and passes with the factory installed.

Fixes gh-1336
