### PR TITLE
refactor: fix FieldMayBeFinal warnings across modules

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
@@ -50,7 +50,7 @@ import org.springframework.util.StringUtils;
  */
 public final class AWSLambdaUtils {
 
-	private static Log logger = LogFactory.getLog(AWSLambdaUtils.class);
+	private static final Log logger = LogFactory.getLog(AWSLambdaUtils.class);
 
 	static final String AWS_API_GATEWAY = "aws-api-gateway";
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoop.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoop.java
@@ -67,7 +67,7 @@ import static org.apache.http.HttpHeaders.USER_AGENT;
  */
 public final class CustomRuntimeEventLoop implements SmartLifecycle {
 
-	private static Log logger = LogFactory.getLog(CustomRuntimeEventLoop.class);
+	private static final Log logger = LogFactory.getLog(CustomRuntimeEventLoop.class);
 
 	static final String LAMBDA_VERSION_DATE = "2018-06-01";
 	private static final String LAMBDA_ERROR_URL_TEMPLATE = "http://{0}/{1}/runtime/invocation/{2}/error";
@@ -84,7 +84,7 @@ public final class CustomRuntimeEventLoop implements SmartLifecycle {
 
 	private volatile boolean running;
 
-	private ExecutorService executor = Executors.newSingleThreadExecutor();
+	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
 	private FunctionInvocationWrapper routingFunction;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeInitializer.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeInitializer.java
@@ -31,7 +31,7 @@ import org.springframework.util.StringUtils;
  */
 public class CustomRuntimeInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
 
-	private static Log logger = LogFactory.getLog(CustomRuntimeInitializer.class);
+	private static final Log logger = LogFactory.getLog(CustomRuntimeInitializer.class);
 
 	@Override
 	public void initialize(GenericApplicationContext context) {

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/FunctionInvoker.java
@@ -55,7 +55,7 @@ import org.springframework.util.StringUtils;
  */
 public class FunctionInvoker implements RequestStreamHandler {
 
-	private static Log logger = LogFactory.getLog(FunctionInvoker.class);
+	private static final Log logger = LogFactory.getLog(FunctionInvoker.class);
 
 	private JsonMapper jsonMapper;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/LambdaDestinationResolver.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/LambdaDestinationResolver.java
@@ -35,7 +35,7 @@ import org.springframework.messaging.MessageHeaders;
  */
 public class LambdaDestinationResolver implements DestinationResolver {
 
-	private static Log logger = LogFactory.getLog(LambdaDestinationResolver.class);
+	private static final Log logger = LogFactory.getLog(LambdaDestinationResolver.class);
 
 	@Override
 	public String destination(Supplier<?> supplier, String name, Object value) {

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoopTest.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoopTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class CustomRuntimeEventLoopTest {
 
-	private String API_EVENT = "{\n"
+	private final String API_EVENT = "{\n"
 			+ "    \"version\": \"1.0\",\n"
 			+ "    \"resource\": \"$default\",\n"
 			+ "    \"path\": \"/question\",\n"

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/AzureWebProxyInvokerTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/AzureWebProxyInvokerTests.java
@@ -121,7 +121,7 @@ public class AzureWebProxyInvokerTests {
 	public static class BuilderStub implements Builder {
 
 		private HttpStatusType status;
-		private Map<String, String> headers = new HashMap<>();
+		private final Map<String, String> headers = new HashMap<>();
 		private Object body;
 
 		@Override
@@ -151,9 +151,9 @@ public class AzureWebProxyInvokerTests {
 
 	public static class HttpResponseMessageStub implements HttpResponseMessage {
 
-		private HttpStatusType status;
-		private Map<String, String> headers = new HashMap<>();
-		private Object body;
+		private final HttpStatusType status;
+		private final Map<String, String> headers;
+		private final Object body;
 
 		HttpResponseMessageStub(HttpStatusType status, Map<String, String> headers,
 				Object body) {

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/PetData.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/PetData.java
@@ -28,81 +28,81 @@ public final class PetData {
 	private PetData() {
 
 	}
-	private static List<String> breeds = new ArrayList<>();
+	private static final List<String> BREEDS = new ArrayList<>();
 	static {
-		breeds.add("Afghan Hound");
-		breeds.add("Beagle");
-		breeds.add("Bernese Mountain Dog");
-		breeds.add("Bloodhound");
-		breeds.add("Dalmatian");
-		breeds.add("Jack Russell Terrier");
-		breeds.add("Norwegian Elkhound");
+		BREEDS.add("Afghan Hound");
+		BREEDS.add("Beagle");
+		BREEDS.add("Bernese Mountain Dog");
+		BREEDS.add("Bloodhound");
+		BREEDS.add("Dalmatian");
+		BREEDS.add("Jack Russell Terrier");
+		BREEDS.add("Norwegian Elkhound");
 	}
 
-	private static List<String> names = new ArrayList<>();
+	private static final List<String> NAMES = new ArrayList<>();
 	static {
-		names.add("Bailey");
-		names.add("Bella");
-		names.add("Max");
-		names.add("Lucy");
-		names.add("Charlie");
-		names.add("Molly");
-		names.add("Buddy");
-		names.add("Daisy");
-		names.add("Rocky");
-		names.add("Maggie");
-		names.add("Jake");
-		names.add("Sophie");
-		names.add("Jack");
-		names.add("Sadie");
-		names.add("Toby");
-		names.add("Chloe");
-		names.add("Cody");
-		names.add("Bailey");
-		names.add("Buster");
-		names.add("Lola");
-		names.add("Duke");
-		names.add("Zoe");
-		names.add("Cooper");
-		names.add("Abby");
-		names.add("Riley");
-		names.add("Ginger");
-		names.add("Harley");
-		names.add("Roxy");
-		names.add("Bear");
-		names.add("Gracie");
-		names.add("Tucker");
-		names.add("Coco");
-		names.add("Murphy");
-		names.add("Sasha");
-		names.add("Lucky");
-		names.add("Lily");
-		names.add("Oliver");
-		names.add("Angel");
-		names.add("Sam");
-		names.add("Princess");
-		names.add("Oscar");
-		names.add("Emma");
-		names.add("Teddy");
-		names.add("Annie");
-		names.add("Winston");
-		names.add("Rosie");
+		NAMES.add("Bailey");
+		NAMES.add("Bella");
+		NAMES.add("Max");
+		NAMES.add("Lucy");
+		NAMES.add("Charlie");
+		NAMES.add("Molly");
+		NAMES.add("Buddy");
+		NAMES.add("Daisy");
+		NAMES.add("Rocky");
+		NAMES.add("Maggie");
+		NAMES.add("Jake");
+		NAMES.add("Sophie");
+		NAMES.add("Jack");
+		NAMES.add("Sadie");
+		NAMES.add("Toby");
+		NAMES.add("Chloe");
+		NAMES.add("Cody");
+		NAMES.add("Bailey");
+		NAMES.add("Buster");
+		NAMES.add("Lola");
+		NAMES.add("Duke");
+		NAMES.add("Zoe");
+		NAMES.add("Cooper");
+		NAMES.add("Abby");
+		NAMES.add("Riley");
+		NAMES.add("Ginger");
+		NAMES.add("Harley");
+		NAMES.add("Roxy");
+		NAMES.add("Bear");
+		NAMES.add("Gracie");
+		NAMES.add("Tucker");
+		NAMES.add("Coco");
+		NAMES.add("Murphy");
+		NAMES.add("Sasha");
+		NAMES.add("Lucky");
+		NAMES.add("Lily");
+		NAMES.add("Oliver");
+		NAMES.add("Angel");
+		NAMES.add("Sam");
+		NAMES.add("Princess");
+		NAMES.add("Oscar");
+		NAMES.add("Emma");
+		NAMES.add("Teddy");
+		NAMES.add("Annie");
+		NAMES.add("Winston");
+		NAMES.add("Rosie");
 	}
 
 	public static List<String> getBreeds() {
-		return breeds;
+		return BREEDS;
 	}
 
 	public static List<String> getNames() {
-		return names;
+		return NAMES;
 	}
 
 	public static String getRandomBreed() {
-		return breeds.get(ThreadLocalRandom.current().nextInt(0, breeds.size() - 1));
+		return BREEDS.get(ThreadLocalRandom.current().nextInt(0, BREEDS.size() - 1));
 	}
 
 	public static String getRandomName() {
-		return names.get(ThreadLocalRandom.current().nextInt(0, names.size() - 1));
+		return NAMES.get(ThreadLocalRandom.current().nextInt(0, NAMES.size() - 1));
 	}
 
 	public static Date getRandomDoB() {

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/TestExecutionContext.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/TestExecutionContext.java
@@ -23,7 +23,7 @@ import com.microsoft.azure.functions.ExecutionContext;
 
 public class TestExecutionContext implements ExecutionContext {
 
-	private String name;
+	private final String name;
 
 	public TestExecutionContext(String name) {
 		this.name = name;

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/main/java/org/springframework/cloud/function/adapter/azure/AzureFunctionInstanceInjector.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/main/java/org/springframework/cloud/function/adapter/azure/AzureFunctionInstanceInjector.java
@@ -42,7 +42,7 @@ import org.springframework.util.CollectionUtils;
  */
 public class AzureFunctionInstanceInjector implements FunctionInstanceInjector {
 
-	private static Log logger = LogFactory.getLog(AzureFunctionInstanceInjector.class);
+	private static final Log logger = LogFactory.getLog(AzureFunctionInstanceInjector.class);
 
 	private static ConfigurableApplicationContext APPLICATION_CONTEXT;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/helper/BuilderStub.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/helper/BuilderStub.java
@@ -26,7 +26,7 @@ import com.microsoft.azure.functions.HttpStatusType;
 public class BuilderStub implements Builder {
 
 	private HttpStatusType status;
-	private Map<String, String> headers = new HashMap<>();
+	private final Map<String, String> headers = new HashMap<>();
 	private Object body;
 
 	@Override

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/helper/HttpResponseMessageStub.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/helper/HttpResponseMessageStub.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.function.adapter.azure.helper;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import com.microsoft.azure.functions.HttpResponseMessage;
@@ -24,9 +23,9 @@ import com.microsoft.azure.functions.HttpStatusType;
 
 public class HttpResponseMessageStub implements HttpResponseMessage {
 
-	private HttpStatusType status;
-	private Map<String, String> headers = new HashMap<>();
-	private Object body;
+	private final HttpStatusType status;
+	private final Map<String, String> headers;
+	private final Object body;
 
 	public HttpResponseMessageStub(HttpStatusType status, Map<String, String> headers,
 			Object body) {

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/helper/TestExecutionContext.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/helper/TestExecutionContext.java
@@ -23,7 +23,7 @@ import com.microsoft.azure.functions.ExecutionContext;
 
 public class TestExecutionContext implements ExecutionContext {
 
-	private String name;
+	private final String name;
 
 	public TestExecutionContext(String name) {
 		this.name = name;

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc-cloudevent-ext/src/main/java/org/springframework/cloud/function/grpc/ce/CloudEventHandler.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc-cloudevent-ext/src/main/java/org/springframework/cloud/function/grpc/ce/CloudEventHandler.java
@@ -33,7 +33,7 @@ import org.springframework.cloud.function.grpc.MessageHandlingHelper;
 @SuppressWarnings("rawtypes")
 class CloudEventHandler extends CloudEventServiceImplBase  {
 
-	private Log logger = LogFactory.getLog(CloudEventHandler.class);
+	private final Log logger = LogFactory.getLog(CloudEventHandler.class);
 
 	private final MessageHandlingHelper helper;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcServer.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcServer.java
@@ -45,7 +45,7 @@ import org.springframework.util.ClassUtils;
  */
 class GrpcServer implements SmartLifecycle, EnvironmentAware {
 
-	private Log logger = LogFactory.getLog(GrpcServer.class);
+	private final Log logger = LogFactory.getLog(GrpcServer.class);
 
 	private final FunctionGrpcProperties grpcProperties;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcUtils.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcUtils.java
@@ -49,7 +49,7 @@ import org.springframework.messaging.support.MessageBuilder;
  */
 public final class GrpcUtils {
 
-	private static Log logger = LogFactory.getLog(GrpcUtils.class);
+	private static final Log logger = LogFactory.getLog(GrpcUtils.class);
 
 	private GrpcUtils() {
 

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/MessageHandlingHelper.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/MessageHandlingHelper.java
@@ -54,7 +54,7 @@ import org.springframework.util.CollectionUtils;
  */
 public class MessageHandlingHelper<T extends GeneratedMessageV3> implements SmartLifecycle {
 
-	private Log logger = LogFactory.getLog(MessageHandlingHelper.class);
+	private final Log logger = LogFactory.getLog(MessageHandlingHelper.class);
 
 	private final List<GrpcMessageConverter<?>> grpcConverters;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessHttpServletResponse.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessHttpServletResponse.java
@@ -55,7 +55,7 @@ public class ServerlessHttpServletResponse implements HttpServletResponse {
 
 	private static final String DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
 
-	private String defaultCharacterEncoding = WebUtils.DEFAULT_CHARACTER_ENCODING;
+	private final String defaultCharacterEncoding = WebUtils.DEFAULT_CHARACTER_ENCODING;
 
 	private String characterEncoding = this.defaultCharacterEncoding;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessServletContext.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessServletContext.java
@@ -60,11 +60,11 @@ public class ServerlessServletContext implements ServletContext {
 
 	private static final Log LOGGER = LogFactory.getLog(ServerlessServletContext.class);
 
-	private HashMap<String, Object> attributes = new HashMap<>();
+	private final HashMap<String, Object> attributes = new HashMap<>();
 
-	private Map<String, FilterRegistration> filterRegistrations = new HashMap<>();
+	private final Map<String, FilterRegistration> filterRegistrations = new HashMap<>();
 
-	private static Enumeration<String> EMPTY_ENUM = Collections.enumeration(new ArrayList<String>());
+	private static final Enumeration<String> EMPTY_ENUM = Collections.enumeration(new ArrayList<String>());
 
 	@Override
 	public Enumeration<String> getInitParameterNames() {

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessWebApplication.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessWebApplication.java
@@ -76,17 +76,17 @@ public class ServerlessWebApplication extends SpringApplication {
 
 	private static final Log LOGGER = LogFactory.getLog(ServerlessWebApplication.class);
 
-	private ApplicationStartup applicationStartup = ApplicationStartup.DEFAULT;
+	private final ApplicationStartup applicationStartup = ApplicationStartup.DEFAULT;
 
-	private ApplicationContextFactory applicationContextFactory = ApplicationContextFactory.DEFAULT;
+	private final ApplicationContextFactory applicationContextFactory = ApplicationContextFactory.DEFAULT;
 
 	private boolean allowCircularReferences;
 
 	private boolean allowBeanDefinitionOverriding;
 
-	private boolean logStartupInfo = true;
+	private final boolean logStartupInfo = true;
 
-	private boolean lazyInitialization = false;
+	private final boolean lazyInitialization = false;
 
 	private WebApplicationType webApplicationType;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/serverless/web/RequestResponseTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/serverless/web/RequestResponseTests.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class RequestResponseTests {
 
-	private ObjectMapper mapper = new ObjectMapper();
+	private final ObjectMapper mapper = new ObjectMapper();
 
 	private ServerlessMVC mvc;
 

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/test/app/PetData.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/test/app/PetData.java
@@ -25,86 +25,86 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 public final class PetData {
-	private static List<String> breeds = new ArrayList<>();
+	private static final List<String> BREEDS = new ArrayList<>();
 
 	private PetData() {
 
 	}
 
 	static {
-		breeds.add("Afghan Hound");
-		breeds.add("Beagle");
-		breeds.add("Bernese Mountain Dog");
-		breeds.add("Bloodhound");
-		breeds.add("Dalmatian");
-		breeds.add("Jack Russell Terrier");
-		breeds.add("Norwegian Elkhound");
+		BREEDS.add("Afghan Hound");
+		BREEDS.add("Beagle");
+		BREEDS.add("Bernese Mountain Dog");
+		BREEDS.add("Bloodhound");
+		BREEDS.add("Dalmatian");
+		BREEDS.add("Jack Russell Terrier");
+		BREEDS.add("Norwegian Elkhound");
 	}
 
-	private static List<String> names = new ArrayList<>();
+	private static final List<String> NAMES = new ArrayList<>();
 	static {
-		names.add("Bailey");
-		names.add("Bella");
-		names.add("Max");
-		names.add("Lucy");
-		names.add("Charlie");
-		names.add("Molly");
-		names.add("Buddy");
-		names.add("Daisy");
-		names.add("Rocky");
-		names.add("Maggie");
-		names.add("Jake");
-		names.add("Sophie");
-		names.add("Jack");
-		names.add("Sadie");
-		names.add("Toby");
-		names.add("Chloe");
-		names.add("Cody");
-		names.add("Bailey");
-		names.add("Buster");
-		names.add("Lola");
-		names.add("Duke");
-		names.add("Zoe");
-		names.add("Cooper");
-		names.add("Abby");
-		names.add("Riley");
-		names.add("Ginger");
-		names.add("Harley");
-		names.add("Roxy");
-		names.add("Bear");
-		names.add("Gracie");
-		names.add("Tucker");
-		names.add("Coco");
-		names.add("Murphy");
-		names.add("Sasha");
-		names.add("Lucky");
-		names.add("Lily");
-		names.add("Oliver");
-		names.add("Angel");
-		names.add("Sam");
-		names.add("Princess");
-		names.add("Oscar");
-		names.add("Emma");
-		names.add("Teddy");
-		names.add("Annie");
-		names.add("Winston");
-		names.add("Rosie");
+		NAMES.add("Bailey");
+		NAMES.add("Bella");
+		NAMES.add("Max");
+		NAMES.add("Lucy");
+		NAMES.add("Charlie");
+		NAMES.add("Molly");
+		NAMES.add("Buddy");
+		NAMES.add("Daisy");
+		NAMES.add("Rocky");
+		NAMES.add("Maggie");
+		NAMES.add("Jake");
+		NAMES.add("Sophie");
+		NAMES.add("Jack");
+		NAMES.add("Sadie");
+		NAMES.add("Toby");
+		NAMES.add("Chloe");
+		NAMES.add("Cody");
+		NAMES.add("Bailey");
+		NAMES.add("Buster");
+		NAMES.add("Lola");
+		NAMES.add("Duke");
+		NAMES.add("Zoe");
+		NAMES.add("Cooper");
+		NAMES.add("Abby");
+		NAMES.add("Riley");
+		NAMES.add("Ginger");
+		NAMES.add("Harley");
+		NAMES.add("Roxy");
+		NAMES.add("Bear");
+		NAMES.add("Gracie");
+		NAMES.add("Tucker");
+		NAMES.add("Coco");
+		NAMES.add("Murphy");
+		NAMES.add("Sasha");
+		NAMES.add("Lucky");
+		NAMES.add("Lily");
+		NAMES.add("Oliver");
+		NAMES.add("Angel");
+		NAMES.add("Sam");
+		NAMES.add("Princess");
+		NAMES.add("Oscar");
+		NAMES.add("Emma");
+		NAMES.add("Teddy");
+		NAMES.add("Annie");
+		NAMES.add("Winston");
+		NAMES.add("Rosie");
 	}
 
 	public static List<String> getBreeds() {
-		return breeds;
+		return BREEDS;
 	}
 
 	public static List<String> getNames() {
-		return names;
+		return NAMES;
 	}
 
 	public static String getRandomBreed() {
-		return breeds.get(ThreadLocalRandom.current().nextInt(0, breeds.size() - 1));
+		return BREEDS.get(ThreadLocalRandom.current().nextInt(0, BREEDS.size() - 1));
 	}
 
 	public static String getRandomName() {
-		return names.get(ThreadLocalRandom.current().nextInt(0, names.size() - 1));
+		return NAMES.get(ThreadLocalRandom.current().nextInt(0, NAMES.size() - 1));
 	}
 
 	public static Date getRandomDoB() {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionInvocationHelper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionInvocationHelper.java
@@ -47,7 +47,7 @@ import org.springframework.util.StringUtils;
  */
 public class CloudEventsFunctionInvocationHelper implements FunctionInvocationHelper<Message<?>>, ApplicationContextAware {
 
-	private Log logger = LogFactory.getLog(this.getClass());
+	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private ConfigurableApplicationContext applicationContext;
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistry.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Oleg Zhurakousky
  * @author Soby Chacko
+ * @author Roman Akentev
  */
 public class BeanFactoryAwareFunctionRegistry extends SimpleFunctionRegistry implements ApplicationContextAware {
 
@@ -72,6 +73,12 @@ public class BeanFactoryAwareFunctionRegistry extends SimpleFunctionRegistry imp
 	public BeanFactoryAwareFunctionRegistry(ConversionService conversionService, CompositeMessageConverter messageConverter,
 			JsonMapper jsonMapper, @Nullable FunctionProperties functionProperties, @Nullable FunctionInvocationHelper<Message<?>> functionInvocationHelper) {
 		super(conversionService, messageConverter, jsonMapper, functionProperties, functionInvocationHelper);
+	}
+
+	public BeanFactoryAwareFunctionRegistry(ConversionService conversionService, CompositeMessageConverter messageConverter,
+			JsonMapper jsonMapper, @Nullable FunctionProperties functionProperties, @Nullable FunctionInvocationHelper<Message<?>> functionInvocationHelper,
+			int wrappedFunctionDefinitionsCacheSize) {
+		super(conversionService, messageConverter, jsonMapper, functionProperties, functionInvocationHelper, wrappedFunctionDefinitionsCacheSize);
 	}
 
 	@Override

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -84,9 +84,9 @@ import org.springframework.util.StringUtils;
  */
 public final class FunctionTypeUtils {
 
-	private static Log logger = LogFactory.getLog(FunctionTypeUtils.class);
+	private static final Log logger = LogFactory.getLog(FunctionTypeUtils.class);
 
-	private static Type ROUTING_FUNCTION_TYPE = discoverFunctionTypeFromClass(RoutingFunction.class);
+	private static final Type ROUTING_FUNCTION_TYPE = discoverFunctionTypeFromClass(RoutingFunction.class);
 
 	private FunctionTypeUtils() {
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -113,8 +113,6 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 
 	private final FunctionProperties functionProperties;
 
-	private int wrappedFunctionDefinitionsCacheSize = 1000;
-
 	private final Object cacheLock = new Object();
 
 	@Autowired(required = false)
@@ -123,6 +121,13 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 	public SimpleFunctionRegistry(ConversionService conversionService, CompositeMessageConverter messageConverter, JsonMapper jsonMapper,
 			@Nullable FunctionProperties functionProperties,
 			@Nullable FunctionInvocationHelper<Message<?>> functionInvocationHelper) {
+		this(conversionService, messageConverter, jsonMapper, functionProperties, functionInvocationHelper, 1000);
+	}
+
+	public SimpleFunctionRegistry(ConversionService conversionService, CompositeMessageConverter messageConverter, JsonMapper jsonMapper,
+			@Nullable FunctionProperties functionProperties,
+			@Nullable FunctionInvocationHelper<Message<?>> functionInvocationHelper,
+			int wrappedFunctionDefinitionsCacheSize) {
 		Assert.notNull(messageConverter, "'messageConverter' must not be null");
 		Assert.notNull(jsonMapper, "'jsonMapper' must not be null");
 		this.conversionService = conversionService;
@@ -448,7 +453,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 
 		private boolean composed;
 
-		private boolean message;
+		private final boolean message;
 
 		private String[] expectedOutputContentType;
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
@@ -40,6 +40,7 @@ import tools.jackson.datatype.joda.JodaModule;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -103,6 +104,7 @@ import org.springframework.util.StringUtils;
 @AutoConfigureAfter(name = {"org.springframework.cloud.function.deployer.FunctionDeployerConfiguration"})
 public class ContextFunctionCatalogAutoConfiguration {
 
+
 	/**
 	 * The name of the property to specify desired JSON mapper. Available values are `jackson' and 'gson'.
 	 */
@@ -113,7 +115,8 @@ public class ContextFunctionCatalogAutoConfiguration {
 	@Bean
 	public FunctionRegistry functionCatalog(List<MessageConverter> messageConverters, JsonMapper jsonMapper,
 											ConfigurableApplicationContext context, @Nullable FunctionInvocationHelper<Message<?>> functionInvocationHelper,
-											FunctionProperties functionProperties) {
+											FunctionProperties functionProperties,
+											@Value("${spring.cloud.function.registry.cache-size:1000}") int wrappedFunctionDefinitionsCacheSize) {
 		ConversionService existing = context.getBeanFactory().getConversionService();
 		ConfigurableConversionService conversionService = (existing instanceof ConfigurableConversionService ccs)
 				? ccs
@@ -163,7 +166,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 		if (functionInvocationHelper instanceof CloudEventsFunctionInvocationHelper cloudEventsFunctionInvocationHelper) {
 			cloudEventsFunctionInvocationHelper.setMessageConverter(messageConverter);
 		}
-		return new BeanFactoryAwareFunctionRegistry(conversionService, messageConverter, jsonMapper, functionProperties, functionInvocationHelper);
+		return new BeanFactoryAwareFunctionRegistry(conversionService, messageConverter, jsonMapper, functionProperties, functionInvocationHelper, wrappedFunctionDefinitionsCacheSize);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializer.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializer.java
@@ -61,6 +61,7 @@ import org.springframework.util.ClassUtils;
 /**
  * @author Dave Syer
  * @author Oleg Zhurakousky
+ * @author Roman Akentev
  *
  */
 public class ContextFunctionCatalogInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
@@ -86,7 +87,7 @@ public class ContextFunctionCatalogInitializer implements ApplicationContextInit
 
 	static class ContextFunctionCatalogBeanRegistrar implements BeanDefinitionRegistryPostProcessor {
 
-		private GenericApplicationContext context;
+		private final GenericApplicationContext context;
 
 		ContextFunctionCatalogBeanRegistrar(GenericApplicationContext applicationContext) {
 			this.context = applicationContext;
@@ -181,7 +182,8 @@ public class ContextFunctionCatalogInitializer implements ApplicationContextInit
 					SmartCompositeMessageConverter messageConverter = new SmartCompositeMessageConverter(messageConverters);
 
 					ConversionService conversionService = new DefaultConversionService();
-					return new SimpleFunctionRegistry(conversionService, messageConverter, this.context.getBean(JsonMapper.class));
+					int cacheSize = this.context.getEnvironment().getProperty("spring.cloud.function.registry.cache-size", int.class, 1000);
+					return new SimpleFunctionRegistry(conversionService, messageConverter, this.context.getBean(JsonMapper.class), null, null, cacheSize);
 				});
 				this.context.registerBean(FunctionProperties.class, () -> new FunctionProperties());
 				this.context.registerBean(FunctionRegistrationPostProcessor.class,

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/RoutingFunction.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/RoutingFunction.java
@@ -66,7 +66,7 @@ public class RoutingFunction implements Function<Object, Object> {
 	 */
 	public static final String DEFAULT_ROUTE_HANDLER = "defaultMessageRoutingHandler";
 
-	private static Log logger = LogFactory.getLog(RoutingFunction.class);
+	private static final Log logger = LogFactory.getLog(RoutingFunction.class);
 
 	private final StandardEvaluationContext evalContext = new StandardEvaluationContext();
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/SmartCompositeMessageConverter.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/SmartCompositeMessageConverter.java
@@ -49,7 +49,7 @@ import org.springframework.util.StringUtils;
  */
 public class SmartCompositeMessageConverter extends CompositeMessageConverter {
 
-	private Log logger = LogFactory.getLog(this.getClass());
+	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private final Supplier<Collection<MessageConverterHelper>> messageConverterHelpersSupplier;
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JacksonMapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JacksonMapper.java
@@ -35,7 +35,7 @@ import tools.jackson.databind.type.TypeFactory;
  */
 public class JacksonMapper extends JsonMapper {
 
-	private static Log logger = LogFactory.getLog(JacksonMapper.class);
+	private static final Log logger = LogFactory.getLog(JacksonMapper.class);
 
 	private final ObjectMapper mapper;
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JsonMapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JsonMapper.java
@@ -42,7 +42,7 @@ import org.springframework.util.MimeTypeUtils;
  */
 public abstract class JsonMapper {
 
-	private static Log logger = LogFactory.getLog(JsonMapper.class);
+	private static final Log logger = LogFactory.getLog(JsonMapper.class);
 
 	// we need this just to validate is String is JSON
 	private static final ObjectMapper mapper = tools.jackson.databind.json.JsonMapper.builder()

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/utils/FunctionClassUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/utils/FunctionClassUtils.java
@@ -44,7 +44,7 @@ import org.springframework.util.StringUtils;
  */
 public final class FunctionClassUtils {
 
-	private static Log logger = LogFactory.getLog(FunctionClassUtils.class);
+	private static final Log logger = LogFactory.getLog(FunctionClassUtils.class);
 
 	private FunctionClassUtils() {
 

--- a/spring-cloud-function-context/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-function-context/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -25,6 +25,12 @@
 			"type": "java.lang.Boolean",
 			"description": "Enables RoutingFunction which delegates incoming request to a function named via function.name header",
 			"defaultValue": false
+		},
+		{
+			"name": "spring.cloud.function.registry.cache-size",
+			"type": "java.lang.Integer",
+			"description": "Maximum number of wrapped function definitions kept in the registry cache. When the cache exceeds this size, the eldest entries are removed.",
+			"defaultValue": 1000
 		}
 	]
 }

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
@@ -88,6 +88,7 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
  *
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Roman Akentev
  *
  */
 public class BeanFactoryAwareFunctionRegistryTests {
@@ -119,11 +120,9 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 	@Test
 	public void testBoundedFunctionCache() throws Exception {
-		FunctionCatalog catalog = this.configureCatalog(CompositionWithNullReturnInBetween.class);
-		Field wrappedFunctionDefinitionsCacheSizeField = ReflectionUtils.findField(catalog.getClass(),
-				"wrappedFunctionDefinitionsCacheSize");
-		wrappedFunctionDefinitionsCacheSizeField.setAccessible(true);
-		wrappedFunctionDefinitionsCacheSizeField.set(catalog, 10);
+		FunctionCatalog catalog = this.configureCatalogWithProperties(
+				new String[] { "--spring.cloud.function.registry.cache-size=10" },
+				CompositionWithNullReturnInBetween.class);
 		Field wrappedFunctionDefinitionsField = ReflectionUtils.findField(catalog.getClass(),
 				"wrappedFunctionDefinitions");
 		wrappedFunctionDefinitionsField.setAccessible(true);
@@ -183,30 +182,30 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		FunctionCatalog catalog = this.configureCatalog(CompositionReactiveSupplierWithConsumer.class);
 		FunctionInvocationWrapper function = catalog.lookup("supplyPrimitive|consume");
 		function.apply(null);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.size()).isEqualTo(2);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(0)).isEqualTo(1);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(1)).isEqualTo(2);
-		CompositionReactiveSupplierWithConsumer.results.clear();
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.size()).isEqualTo(2);
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(0)).isEqualTo(1);
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(1)).isEqualTo(2);
+		CompositionReactiveSupplierWithConsumer.RESULTS.clear();
 
 		function = catalog.lookup("supplyMessage|consume");
 		function.apply(null);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.size()).isEqualTo(2);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(0)).isEqualTo(1);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(1)).isEqualTo(2);
-		CompositionReactiveSupplierWithConsumer.results.clear();
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.size()).isEqualTo(2);
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(0)).isEqualTo(1);
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(1)).isEqualTo(2);
+		CompositionReactiveSupplierWithConsumer.RESULTS.clear();
 
 		function = catalog.lookup("functionMessage|consume");
 		function.apply(Flux.fromArray(new Message[] {MessageBuilder.withPayload("ricky").build(), MessageBuilder.withPayload("bubbles").build()}));
-		assertThat(CompositionReactiveSupplierWithConsumer.results.size()).isEqualTo(2);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(0)).isEqualTo("RICKY");
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(1)).isEqualTo("BUBBLES");
-		CompositionReactiveSupplierWithConsumer.results.clear();
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.size()).isEqualTo(2);
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(0)).isEqualTo("RICKY");
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(1)).isEqualTo("BUBBLES");
+		CompositionReactiveSupplierWithConsumer.RESULTS.clear();
 
 		function = catalog.lookup("functionPrimitive|consume");
 		function.apply(Flux.fromArray(new String[] {"ricky", "bubbles"}));
-		assertThat(CompositionReactiveSupplierWithConsumer.results.size()).isEqualTo(2);
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(0)).isEqualTo("RICKY");
-		assertThat(CompositionReactiveSupplierWithConsumer.results.get(1)).isEqualTo("BUBBLES");
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.size()).isEqualTo(2);
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(0)).isEqualTo("RICKY");
+		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(1)).isEqualTo("BUBBLES");
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1649,7 +1648,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	@Configuration // s-c-f-1141
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public static class CompositionReactiveSupplierWithConsumer {
-		private static List results = new ArrayList<>();
+		private static final List RESULTS = new ArrayList<>();
 
 		@Bean
 		public Function<Flux<String>, Flux<String>> functionPrimitive() {
@@ -1683,7 +1682,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 				if (v instanceof Message vMessage) {
 					v = vMessage.getPayload();
 				}
-				results.add(v);
+				RESULTS.add(v);
 			};
 		}
 	}

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
@@ -469,7 +469,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 	@Configuration
 	protected static class SimpleConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		@Bean
 		public Function<String, String> function() {
@@ -522,7 +522,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 
 	@Component("appendFunction")
 	public static class AppendFunction implements Function<String, String> {
-		private String value;
+		private final String value;
 
 		public AppendFunction(String value) {
 			this.value = value;

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializerTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializerTests.java
@@ -243,7 +243,7 @@ public class ContextFunctionCatalogInitializerTests {
 	protected static class SimpleConfiguration
 			implements ApplicationContextInitializer<GenericApplicationContext> {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 
 		@Override
@@ -331,7 +331,7 @@ public class ContextFunctionCatalogInitializerTests {
 	protected static class GsonConfiguration
 			implements ApplicationContextInitializer<GenericApplicationContext> {
 
-		private Gson gson = new Gson();
+		private final Gson gson = new Gson();
 
 		@Override
 		public void initialize(GenericApplicationContext context) {

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/utils/JsonMaskerTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/utils/JsonMaskerTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonMaskerTests {
 
-	private String event = "{\n"
+	private final String event = "{\n"
 			+ "  \"Records\": [\n"
 			+ "    {\n"
 			+ "      \"eventID\": \"f07f8ca4b0b26cb9c4e5e77e69f274ee\",\n"
@@ -192,7 +192,7 @@ public class JsonMaskerTests {
 			+ "  ]\n"
 			+ "}";
 
-	private List<String> maskedKeys = new ArrayList<>();
+	private final List<String> maskedKeys = new ArrayList<>();
 
 	@Test
 	public void validateMasking() throws Exception {

--- a/spring-cloud-function-samples/function-sample-aws-custom-bean/src/main/java/com/example/LambdaApplication.java
+++ b/spring-cloud-function-samples/function-sample-aws-custom-bean/src/main/java/com/example/LambdaApplication.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 @SpringBootApplication
 public class LambdaApplication {
 
-	private static Log logger = LogFactory.getLog(LambdaApplication.class);
+	private static final Log logger = LogFactory.getLog(LambdaApplication.class);
 
 	@Bean
 	public Consumer<String> consume() {

--- a/spring-cloud-function-samples/function-sample-aws-custom/src/main/java/com/example/LambdaApplication.java
+++ b/spring-cloud-function-samples/function-sample-aws-custom/src/main/java/com/example/LambdaApplication.java
@@ -17,7 +17,7 @@ import org.springframework.context.support.GenericApplicationContext;
 public class LambdaApplication
 		implements ApplicationContextInitializer<GenericApplicationContext> {
 
-	private static Log logger = LogFactory.getLog(LambdaApplication.class);
+	private static final Log logger = LogFactory.getLog(LambdaApplication.class);
 
 	public Function<String, String> uppercase() {
 		return value -> {

--- a/spring-cloud-function-samples/function-sample-pojo/src/test/java/com/example/SampleApplicationTests.java
+++ b/spring-cloud-function-samples/function-sample-pojo/src/test/java/com/example/SampleApplicationTests.java
@@ -49,7 +49,7 @@ public class SampleApplicationTests {
 	@LocalServerPort
 	private int port;
 
-	private TestRestTemplate rest = new TestRestTemplate();
+	private final TestRestTemplate rest = new TestRestTemplate();
 
 	@BeforeEach
 	public void before() {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/BasicStringConverter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/BasicStringConverter.java
@@ -31,7 +31,7 @@ public class BasicStringConverter implements StringConverter {
 
 	private ConversionService conversionService;
 
-	private ConfigurableListableBeanFactory registry;
+	private final ConfigurableListableBeanFactory registry;
 
 	public BasicStringConverter(ConfigurableListableBeanFactory registry) {
 		this.registry = registry;

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializer.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializer.java
@@ -79,15 +79,15 @@ import static org.springframework.web.reactive.function.server.ServerResponse.st
  */
 public class FunctionEndpointInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
 
-	private static boolean webflux = ClassUtils
+	private static final boolean WEBFLUX = ClassUtils
 			.isPresent("org.springframework.web.reactive.function.server.RouterFunction", null);
 
-	private static boolean errorAttributes = ClassUtils
+	private static final boolean ERROR_ATTRIBUTES = ClassUtils
 		.isPresent("org.springframework.boot.webflux.error.ErrorAttributes", null);
 
 	@Override
 	public void initialize(GenericApplicationContext context) {
-		if (webflux && ContextFunctionCatalogInitializer.enabled
+		if (WEBFLUX && ContextFunctionCatalogInitializer.enabled
 				&& context.getEnvironment().getProperty(FunctionalSpringApplication.SPRING_WEB_APPLICATION_TYPE,
 						WebApplicationType.class, WebApplicationType.REACTIVE) == WebApplicationType.REACTIVE
 				&& context.getEnvironment().getProperty("spring.functional.enabled", Boolean.class, false)) {
@@ -97,7 +97,7 @@ public class FunctionEndpointInitializer implements ApplicationContextInitialize
 	}
 
 	private void registerWebFluxAutoConfiguration(GenericApplicationContext context) {
-		if (errorAttributes) {
+		if (ERROR_ATTRIBUTES) {
 			context.registerBean(DefaultErrorWebExceptionHandler.class, () -> ErrorHandlerRegistrar.errorHandler(context));
 		}
 		context.registerBean(WebHttpHandlerBuilder.WEB_HANDLER_BEAN_NAME, HttpWebHandlerAdapter.class,
@@ -132,9 +132,9 @@ public class FunctionEndpointInitializer implements ApplicationContextInitialize
 
 	private static class ServerListener implements SmartApplicationListener {
 
-		private static Log logger = LogFactory.getLog(ServerListener.class);
+		private static final Log logger = LogFactory.getLog(ServerListener.class);
 
-		private GenericApplicationContext context;
+		private final GenericApplicationContext context;
 
 		ServerListener(GenericApplicationContext context) {
 			this.context = context;
@@ -190,7 +190,7 @@ public class FunctionEndpointInitializer implements ApplicationContextInitialize
 
 class FunctionEndpointFactory {
 
-	private static Log logger = LogFactory.getLog(FunctionEndpointFactory.class);
+	private static final Log logger = LogFactory.getLog(FunctionEndpointFactory.class);
 
 	private final FunctionCatalog functionCatalog;
 

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/ExporterProperties.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/ExporterProperties.java
@@ -43,12 +43,12 @@ public class ExporterProperties {
 	/**
 	 * Properties related to a source of items (via an HTTP GET on startup).
 	 */
-	private Source source = new Source();
+	private final Source source = new Source();
 
 	/**
 	 * Properties related to a sink of items (via an HTTP POST on startup).
 	 */
-	private Sink sink = new Sink();
+	private final Sink sink = new Sink();
 
 	/**
 	 * Flag to enable the export of a supplier.
@@ -143,7 +143,7 @@ public class ExporterProperties {
 		/**
 		 * Additional headers to append to the outgoing HTTP requests.
 		 */
-		private Map<String, String> headers = new LinkedHashMap<>();
+		private final Map<String, String> headers = new LinkedHashMap<>();
 
 		/**
 		 * The name of a specific existing Supplier to export from the function catalog.

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/HttpSupplier.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/HttpSupplier.java
@@ -41,9 +41,9 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 public class HttpSupplier implements Supplier<Flux<?>> {
 
-	private static Log logger = LogFactory.getLog(HttpSupplier.class);
+	private static final Log logger = LogFactory.getLog(HttpSupplier.class);
 
-	private WebClient client;
+	private final WebClient client;
 
 	private final ExporterProperties props;
 

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SimpleRequestBuilder.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SimpleRequestBuilder.java
@@ -38,7 +38,7 @@ class SimpleRequestBuilder implements RequestBuilder {
 
 	private String baseUrl = "http://${destination}";
 
-	private Map<String, String> headers = new LinkedHashMap<>();
+	private final Map<String, String> headers = new LinkedHashMap<>();
 
 	private final Environment environment;
 

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SupplierExporter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SupplierExporter.java
@@ -47,7 +47,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 public class SupplierExporter implements SmartLifecycle {
 
-	private static Log logger = LogFactory.getLog(SupplierExporter.class);
+	private static final Log logger = LogFactory.getLog(SupplierExporter.class);
 
 	private final FunctionCatalog catalog;
 

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/FunctionWebRequestProcessingHelper.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/FunctionWebRequestProcessingHelper.java
@@ -51,7 +51,7 @@ import org.springframework.util.StringUtils;
  */
 public final class FunctionWebRequestProcessingHelper {
 
-	private static Log logger = LogFactory.getLog(FunctionWebRequestProcessingHelper.class);
+	private static final Log logger = LogFactory.getLog(FunctionWebRequestProcessingHelper.class);
 
 	private FunctionWebRequestProcessingHelper() {
 

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/HeaderUtils.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/HeaderUtils.java
@@ -38,9 +38,9 @@ public final class HeaderUtils {
 	 */
 	public static final String HTTP_REQUEST_PARAM = "http_request_param";
 
-	private static HttpHeaders IGNORED = new HttpHeaders();
+	private static final HttpHeaders IGNORED = new HttpHeaders();
 
-	private static HttpHeaders REQUEST_ONLY = new HttpHeaders();
+	private static final HttpHeaders REQUEST_ONLY = new HttpHeaders();
 
 	static {
 		IGNORED.add(MessageHeaders.ID, "");

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/flux/FluxRestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/flux/FluxRestApplicationTests.java
@@ -298,7 +298,7 @@ public class FluxRestApplicationTests {
 	@Configuration
 	public static class TestConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		@PostMapping({ "/uppercase", "/transform", "/post/more" })
 		public Flux<?> uppercase(@RequestBody List<String> flux) {

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/mvc/MvcRestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/mvc/MvcRestApplicationTests.java
@@ -287,7 +287,7 @@ public class MvcRestApplicationTests {
 	@Configuration
 	public static class TestConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		@PostMapping({ "/uppercase", "/transform", "/post/more" })
 		public Flux<?> uppercase(@RequestBody List<String> flux) {

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/FunctionalExporterTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/FunctionalExporterTests.java
@@ -68,11 +68,11 @@ public class FunctionalExporterTests {
 
 	private static ConfigurableApplicationContext context;
 
-	private static Map<String, Object> headers = new HashMap<>();
+	private static final Map<String, Object> HEADERS = new HashMap<>();
 
 	@BeforeAll
 	public static void init() throws Exception {
-		headers.clear();
+		HEADERS.clear();
 		String port = "" + TestSocketUtils.findAvailableTcpPort();
 		System.setProperty("server.port", port);
 		System.setProperty("my.port", port);
@@ -85,7 +85,7 @@ public class FunctionalExporterTests {
 
 	@AfterAll
 	public static void close() {
-		headers.clear();
+		HEADERS.clear();
 		System.clearProperty("server.port");
 		if (context != null) {
 			context.close();
@@ -101,8 +101,8 @@ public class FunctionalExporterTests {
 		// It completed
 		assertThat(FunctionalExporterTests.app.inputs).contains("HELLO");
 		assertThat(this.forwarder.isOk()).isTrue();
-		assertThat(headers.containsKey("scf-sink-url"));
-		assertThat(headers.containsKey("scf-func-name"));
+		assertThat(HEADERS.containsKey("scf-sink-url"));
+		assertThat(HEADERS.containsKey("scf-func-name"));
 	}
 
 	@SpringBootConfiguration
@@ -111,7 +111,7 @@ public class FunctionalExporterTests {
 
 		Function<Message<Person>, Message<String>> uppercase() {
 			return value -> {
-				headers.putAll(value.getHeaders());
+				HEADERS.putAll(value.getHeaders());
 				return MessageBuilder.withPayload(value.getPayload().getName().toUpperCase(Locale.ROOT))
 					.copyHeaders(value.getHeaders()).build();
 			};

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/RestConfiguration.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/RestConfiguration.java
@@ -38,11 +38,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class RestConfiguration {
 
-	private static Log logger = LogFactory.getLog(RestConfiguration.class);
+	private static final Log logger = LogFactory.getLog(RestConfiguration.class);
 
 	List<String> inputs = new ArrayList<>();
 
-	private Iterator<String> outputs = Arrays.asList("hello", "world").iterator();
+	private final Iterator<String> outputs = Arrays.asList("hello", "world").iterator();
 
 	@GetMapping("/")
 	ResponseEntity<String> home() {

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/RestPojoConfiguration.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/test/RestPojoConfiguration.java
@@ -38,11 +38,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class RestPojoConfiguration {
 
-	private static Log logger = LogFactory.getLog(RestPojoConfiguration.class);
+	private static final Log logger = LogFactory.getLog(RestPojoConfiguration.class);
 
 	List<String> inputs = new ArrayList<>();
 
-	private Iterator<String> outputs = Arrays.asList("{\"name\":\"hello\"}").iterator();
+	private final Iterator<String> outputs = Arrays.asList("{\"name\":\"hello\"}").iterator();
 
 	@GetMapping("/")
 	ResponseEntity<String> home() {

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpGetIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpGetIntegrationTests.java
@@ -260,7 +260,7 @@ public class HttpGetIntegrationTests {
 	@TestConfiguration
 	public static class ApplicationConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		public static void main(String[] args) throws Exception {
 			SpringApplication.run(HttpGetIntegrationTests.ApplicationConfiguration.class,

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpPostIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpPostIntegrationTests.java
@@ -411,7 +411,7 @@ public class HttpPostIntegrationTests {
 	@Configuration(proxyBeanMethods = false)
 	public static class ApplicationConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		private static int functionReactiveInvocations;
 

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpDeleteIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpDeleteIntegrationTests.java
@@ -97,7 +97,7 @@ public class HttpDeleteIntegrationTests {
 	@TestConfiguration
 	public static class ApplicationConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		public static void main(String[] args) throws Exception {
 			SpringApplication.run(HttpDeleteIntegrationTests.ApplicationConfiguration.class,

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpGetIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpGetIntegrationTests.java
@@ -274,7 +274,7 @@ public class HttpGetIntegrationTests {
 	@TestConfiguration
 	public static class ApplicationConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		public static void main(String[] args) throws Exception {
 			SpringApplication.run(HttpGetIntegrationTests.ApplicationConfiguration.class,

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpPostIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpPostIntegrationTests.java
@@ -341,7 +341,7 @@ public class HttpPostIntegrationTests {
 	@TestConfiguration
 	public static class ApplicationConfiguration {
 
-		private List<String> list = new ArrayList<>();
+		private final List<String> list = new ArrayList<>();
 
 		public static void main(String[] args) throws Exception {
 			SpringApplication.run(HttpPostIntegrationTests.ApplicationConfiguration.class,

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationIntegrationTests.java
@@ -104,11 +104,11 @@ public class FunctionAutoConfigurationIntegrationTests {
 	@RestController
 	public static class RestConfiguration {
 
-		private static Log logger = LogFactory.getLog(RestConfiguration.class);
+		private static final Log logger = LogFactory.getLog(RestConfiguration.class);
 
-		private List<String> inputs = new ArrayList<>();
+		private final List<String> inputs = new ArrayList<>();
 
-		private Iterator<String> outputs = Arrays.asList("hello", "world").iterator();
+		private final Iterator<String> outputs = Arrays.asList("hello", "world").iterator();
 
 		@GetMapping("/")
 		ResponseEntity<String> home() {

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationWithRetriesIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/FunctionAutoConfigurationWithRetriesIntegrationTests.java
@@ -109,9 +109,9 @@ public class FunctionAutoConfigurationWithRetriesIntegrationTests {
 		@Autowired
 		private SupplierExporter forwarder;
 
-		private static Log logger = LogFactory.getLog(RestConfiguration.class);
+		private static final Log logger = LogFactory.getLog(RestConfiguration.class);
 
-		private List<String> inputs = new ArrayList<>();
+		private final List<String> inputs = new ArrayList<>();
 
 		private int counter;
 

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/WebAppIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/source/WebAppIntegrationTests.java
@@ -56,7 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"spring.cloud.function.web.export.autoStartup=false" })
 public class WebAppIntegrationTests {
 
-	private static Log logger = LogFactory.getLog(WebAppIntegrationTests.class);
+	private static final Log logger = LogFactory.getLog(WebAppIntegrationTests.class);
 
 	@Autowired
 	private SupplierExporter forwarder;
@@ -87,9 +87,9 @@ public class WebAppIntegrationTests {
 	@RestController
 	public static class ApplicationConfiguration {
 
-		private List<String> values = new ArrayList<>();
+		private final List<String> values = new ArrayList<>();
 
-		private CountDownLatch latch = new CountDownLatch(1);
+		private final CountDownLatch latch = new CountDownLatch(1);
 
 		@Bean
 		public Supplier<String> word() {


### PR DESCRIPTION
Hi @olegz!

I wanted to give the project a bit more love and hopefully help revive the somewhat stalled maintenance pace, starting with simple cosmetic changes.

Specifically, I went through the IntelliJ FieldMayBeFinal inspection warnings and fixed them across the codebase. Most changes are straightforward final additions, though a few required a bit more care:

- SimpleFunctionRegistry.wrappedFunctionDefinitionsCacheSize - removed the field entirely. The value is only used in the anonymous LinkedHashMap.removeEldestEntry(), so the constructor parameter is captured directly
- Made cache size configurable via spring.cloud.function.registry.cache-size property (default 1000) since the old test used reflection on a now-removed field
- Renamed private static final fields that didn't follow UPPER_CASE convention (breeds→BREEDS, names→NAMES, results→RESULTS, webflux→WEBFLUX, errorAttributes→ERROR_ATTRIBUTES, headers→HEADERS)

Let me know if anything needs adjustments!