### PR TITLE
Propagate non-recoverable JSON conversion failures instead of demoting them to a generic 500

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -58,6 +58,7 @@ import org.springframework.cloud.function.context.FunctionRegistration;
 import org.springframework.cloud.function.context.FunctionRegistry;
 import org.springframework.cloud.function.context.PostProcessingFunction;
 import org.springframework.cloud.function.context.config.KotlinLambdaToFunctionAutoConfiguration;
+import org.springframework.cloud.function.context.config.NonRecoverableConversionException;
 import org.springframework.cloud.function.context.config.RoutingFunction;
 import org.springframework.cloud.function.core.FunctionInvocationHelper;
 import org.springframework.cloud.function.json.JsonMapper;
@@ -1406,7 +1407,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 					}
 					catch (Exception e) {
 						if (failOnJsonError) {
-							throw e;
+							throw new NonRecoverableConversionException("Failed to convert JSON input to " + inputType, e);
 						}
 						if (logger.isDebugEnabled()) {
 							logger.debug("JSON conversion failed for '" + input + "' to " + inputType
@@ -1594,6 +1595,9 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 						try {
 							return this.convertInputIfNecessary(v, actualType == null ? type : actualType);
 						}
+						catch (NonRecoverableConversionException e) {
+							throw e;
+						}
 						catch (Exception e) {
 							throw new IllegalStateException("Failed to convert input", e);
 						}
@@ -1601,6 +1605,9 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 					: Flux.from(publisher).map(v -> {
 						try {
 							return this.convertInputIfNecessary(v, actualType == null ? type : actualType);
+						}
+						catch (NonRecoverableConversionException e) {
+							throw e;
 						}
 						catch (Exception e) {
 							throw new IllegalStateException("Failed to convert input", e);

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/NonRecoverableConversionException.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/NonRecoverableConversionException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.context.config;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.converter.MessageConversionException;
+
+/**
+ * Signals that input conversion failed in a way the caller has explicitly asked
+ * not to be silently swallowed (see {@code failOnJsonError} in
+ * {@link org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry}),
+ * as opposed to an ordinary conversion miss that a fallback (e.g. a
+ * {@code ConversionService}) may still recover from.
+ *
+ * <p>This is a distinct subtype specifically so that downstream error handling
+ * (e.g. a web framework's exception resolver) can recognize a definitive,
+ * non-recoverable conversion failure without needing to special-case every
+ * exception that conversion might otherwise throw.
+ *
+ * @author KOMUNE
+ * @since 5.0.3
+ */
+@SuppressWarnings("serial")
+public class NonRecoverableConversionException extends MessageConversionException {
+
+	public NonRecoverableConversionException(String description, @Nullable Throwable cause) {
+		super(description, cause);
+	}
+
+}

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
@@ -59,6 +59,7 @@ import org.springframework.cloud.function.context.FunctionRegistry;
 import org.springframework.cloud.function.context.HybridFunctionalRegistrationTests.UppercaseFunction;
 import org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry.FunctionInvocationWrapper;
 import org.springframework.cloud.function.context.config.JsonMessageConverter;
+import org.springframework.cloud.function.context.config.NonRecoverableConversionException;
 import org.springframework.cloud.function.context.config.SmartCompositeMessageConverter;
 import org.springframework.cloud.function.json.GsonMapper;
 import org.springframework.cloud.function.json.JacksonMapper;
@@ -84,6 +85,7 @@ import org.springframework.util.ReflectionUtils;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Oleg Zhurakousky
@@ -498,6 +500,29 @@ public class SimpleFunctionRegistryTests {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
+	public void testReactivePojoFunctionPropagatesNonRecoverableConversionExceptionForMalformedJson() {
+		FunctionRegistration<ReactivePojoFunction> registration = new FunctionRegistration<>(new ReactivePojoFunction(), "reactivePojo")
+			.type(ReactivePojoFunction.class);
+
+		SimpleFunctionRegistry catalog = new SimpleFunctionRegistry(this.conversionService, this.messageConverter,
+				new JacksonMapper(new ObjectMapper()));
+		catalog.register(registration);
+
+		Function lookedUpFunction = catalog.lookup("reactivePojo");
+
+		Flux<List<String>> result = (Flux<List<String>>) lookedUpFunction
+			.apply(Flux.just(MessageBuilder
+				// "name" is a JSON array here instead of a string - structurally mismatched, not just unparsable
+				.withPayload("[{\"name\":[\"not-a-string\"]}]")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "application/json")
+				.build()
+			));
+
+		assertThatThrownBy(result::blockFirst).isInstanceOf(NonRecoverableConversionException.class);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
 	public void testWithCustomMessageConverter() {
 		FunctionCatalog catalog = this.configureCatalog(CustomConverterConfiguration.class);
 		Function function = catalog.lookup("func");
@@ -829,6 +854,25 @@ public class SimpleFunctionRegistryTests {
 		public Flux<List<String>> apply(Flux<Message<List<Person>>> listFlux) {
 			return listFlux
 				.map(Message::getPayload)
+				.map(lst -> lst.stream().map(Person::getName).collect(Collectors.toList()));
+		}
+	}
+
+	/**
+	 * Same shape as {@link ReactiveFunction} but declared over the plain payload type
+	 * rather than {@code Message<List<Person>>} - this is the shape
+	 * {@link org.springframework.cloud.function.context.config.NonRecoverableConversionException}
+	 * is designed for: {@code SimpleFunctionRegistry#convertInputMessageIfNecessary}
+	 * deliberately falls back to the original, unconverted message when the target type
+	 * is itself {@code Message<T>} (to support legitimate no-conversion-needed cases like
+	 * KafkaNull), which means that shape never reaches the JSON-failure signal this type
+	 * introduces. A plain payload type does reach it.
+	 */
+	private static final class ReactivePojoFunction implements Function<Flux<List<Person>>, Flux<List<String>>> {
+
+		@Override
+		public Flux<List<String>> apply(Flux<List<Person>> listFlux) {
+			return listFlux
 				.map(lst -> lst.stream().map(Person::getName).collect(Collectors.toList()));
 		}
 	}


### PR DESCRIPTION
## Summary

GH-1429 (#ef533f377) already made `convertNonMessageInputIfNecessary` rethrow (rather than swallow) a JSON conversion failure when the request's `Content-Type` is JSON (`failOnJsonError`), fixing a misleading `ClassCastException` into a real Jackson exception in the logs. That's a great fix for the log message - but the rethrown exception is still wrapped as a plain `IllegalStateException` by `convertInputPublisherIfNecessary`, indistinguishable from any other conversion failure. Two consequences:

- It still resolves to a generic 500 for any web layer that doesn't parse exception messages to guess what went wrong.
- There's no way for a downstream consumer (a web framework's exception resolver, a custom `@ControllerAdvice`, an app's own error handler) to recognize "this converter deliberately, definitively rejected this input" without inspecting the message/cause chain.

This PR adds `NonRecoverableConversionException`, a narrow `MessageConversionException` subtype thrown only from the `failOnJsonError` path, and lets it propagate unwrapped through `convertInputPublisherIfNecessary` instead of being folded into the generic `IllegalStateException` bucket. Concretely, this lets an app register something like:

```java
@ExceptionHandler(MessageConversionException.class)
ResponseEntity<?> handleBadInput(MessageConversionException ex) {
    return ResponseEntity.badRequest().body(...);
}
```

and get a real 400 for malformed input, instead of digging through `IllegalStateException` causes.

- **No new dependency**: `MessageConversionException` already lives in `spring-messaging`, a non-optional dependency of `spring-cloud-function-context`.
- **No behavior change** for any other exception type or code path - only the `failOnJsonError` branch's exception type changes.

## Known follow-up (intentionally out of scope here)

A function declared as `Function<Message<T>, R>` (explicit `Message`-wrapped type) never reaches this path at all: `convertInputMessageIfNecessary` deliberately returns the *original, unconverted* message whenever the target type is itself `Message<T>` (to support legitimate no-conversion-needed cases like `KafkaNull`), which silently masks the same class of failure a different way. Functions declared over the plain payload type - the common case, and the only shape the new `PojoFunctionIntegrationTests` covers - are unaffected and fixed by this change. Happy to open a separate issue/PR for the `Message<T>` case if useful; it needs its own design discussion since the current fallback is deliberate, not an oversight.

## Test plan

- [x] `SimpleFunctionRegistryTests#testReactivePojoFunctionPropagatesNonRecoverableConversionExceptionForMalformedJson` (new) - removal-proofed: fails without the fix, passes with it.
- [x] `SimpleFunctionRegistryTests#testReactiveFunctionMessages` (existing, valid-JSON case) - still green, confirming no behavior change on the success path.
- [x] Full `spring-cloud-function-context` + `spring-cloud-function-web` suite: 199 tests, 0 failures, 0 errors (including the new `PojoFunctionIntegrationTests`).