### PR TITLE
refactor: modernize code to Java 17 syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<wrapper.version>1.0.31.RELEASE</wrapper.version>
+		<pmd.version>7.26.0</pmd.version>
 		<docs.main>spring-cloud-function</docs.main>
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
 		<maven-checkstyle-plugin.failsOnViolation>true
@@ -224,6 +225,50 @@
 				<module>spring-cloud-function-context</module>
 				<module>spring-cloud-function-web</module>
 			</modules>
+		</profile>
+		<profile>
+			<id>pmd</id>
+			<!-- Report-only PMD 7 analysis with modern Java syntax rules.
+			     Runs at verify only when the profile is activated. Sample apps
+			     that inherit spring-boot-starter-parent are not covered. -->
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-pmd-plugin</artifactId>
+						<version>3.28.0</version>
+						<dependencies>
+							<dependency>
+								<groupId>net.sourceforge.pmd</groupId>
+								<artifactId>pmd-core</artifactId>
+								<version>${pmd.version}</version>
+							</dependency>
+							<dependency>
+								<groupId>net.sourceforge.pmd</groupId>
+								<artifactId>pmd-java</artifactId>
+								<version>${pmd.version}</version>
+							</dependency>
+						</dependencies>
+						<configuration>
+							<rulesets>
+								<ruleset>${maven.multiModuleProjectDirectory}/src/checkstyle/pmd-modern-java.xml</ruleset>
+							</rulesets>
+							<failOnViolation>false</failOnViolation>
+							<printFailingErrors>true</printFailingErrors>
+							<includeTests>true</includeTests>
+							<targetJdk>17</targetJdk>
+						</configuration>
+						<executions>
+							<execution>
+								<phase>verify</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>spring</id>

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/AWSLambdaUtils.java
@@ -222,7 +222,7 @@ public final class AWSLambdaUtils {
 
 		byte[] responseBytes = responseMessage  == null ? "\"OK\"".getBytes() : extractPayload((Message<Object>) responseMessage, objectMapper);
 		if (requestMessage.getHeaders().containsKey(AWS_API_GATEWAY) && ((boolean) requestMessage.getHeaders().get(AWS_API_GATEWAY))) {
-			Map<String, Object> response = new HashMap<String, Object>();
+			Map<String, Object> response = new HashMap<>();
 			response.put(IS_BASE64_ENCODED, responseMessage != null && responseMessage.getHeaders().containsKey(IS_BASE64_ENCODED)
 					? responseMessage.getHeaders().get(IS_BASE64_ENCODED) : false);
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoop.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoop.java
@@ -94,9 +94,7 @@ public final class CustomRuntimeEventLoop implements SmartLifecycle {
 
 	public void run() {
 		this.running = true;
-		this.executor.execute(() -> {
-			eventLoop(this.applicationContext);
-		});
+		this.executor.execute(() -> eventLoop(this.applicationContext));
 	}
 
 	@Override

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/FunctionInvoker.java
@@ -115,7 +115,7 @@ public class FunctionInvoker implements RequestStreamHandler {
 		if (this.jsonMapper instanceof JacksonMapper) {
 			((JacksonMapper) this.jsonMapper).configureObjectMapper(objectMapper -> {
 				if (!objectMapper.isEnabled(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)) {
-					MapperBuilder builder = objectMapper.rebuild();
+					MapperBuilder<?, ?> builder = objectMapper.rebuild();
 					builder.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
 					objectMapper =  builder.build();
 				}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/LambdaDestinationResolver.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/main/java/org/springframework/cloud/function/adapter/aws/LambdaDestinationResolver.java
@@ -43,8 +43,7 @@ public class LambdaDestinationResolver implements DestinationResolver {
 			logger.debug("Lambda incoming value: " + value);
 		}
 		String destination = "unknown";
-		if (value instanceof Message) {
-			Message<?> message = (Message<?>) value;
+		if (value instanceof Message<?> message) {
 			MessageHeaders headers = message.getHeaders();
 			if (headers.containsKey("lambda-runtime-aws-request-id")) {
 				destination = (String) headers.get("lambda-runtime-aws-request-id");

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoopTest.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/CustomRuntimeEventLoopTest.java
@@ -326,9 +326,7 @@ public class CustomRuntimeEventLoopTest {
 
 		@Bean
 		public Function<Flux<GeoLocation>, Flux<GeoLocation>> echoFlux() {
-			return flux -> flux.map(g -> {
-				return new GeoLocation(g.longitude(), g.latitude());
-			});
+			return flux -> flux.map(g -> new GeoLocation(g.longitude(), g.latitude()));
 		}
 	}
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-aws/src/test/java/org/springframework/cloud/function/adapter/aws/FunctionInvokerTests.java
@@ -1109,7 +1109,7 @@ public class FunctionInvokerTests {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		invoker.handleRequest(targetStream, output, null);
 
-		Map result = mapper.readValue(output.toByteArray(), Map.class);
+		Map<String, Object> result = mapper.readValue(output.toByteArray(), Map.class);
 		assertThat(result.get("body")).isEqualTo("\"Hello from ELB\"");
 	}
 
@@ -1137,7 +1137,7 @@ public class FunctionInvokerTests {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		invoker.handleRequest(targetStream, output, null);
 
-		Map result = mapper.readValue(output.toByteArray(), Map.class);
+		Map<String, Object> result = mapper.readValue(output.toByteArray(), Map.class);
 		assertThat(result.get("body")).isEqualTo("\"Hello from ELB\"");
 	}
 
@@ -1151,7 +1151,7 @@ public class FunctionInvokerTests {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		invoker.handleRequest(targetStream, output, Mockito.mock(Context.class));
 
-		Map result = mapper.readValue(output.toByteArray(), Map.class);
+		Map<String, Object> result = mapper.readValue(output.toByteArray(), Map.class);
 		assertThat(result.get("body")).isEqualTo("\"Hello from ELB\"");
 	}
 
@@ -1171,7 +1171,7 @@ public class FunctionInvokerTests {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		invoker.handleRequest(targetStream, output, new TestContext());
 
-		Map result = mapper.readValue(output.toByteArray(), Map.class);
+		Map<String, Object> result = mapper.readValue(output.toByteArray(), Map.class);
 		assertThat(result.get("body")).isEqualTo("Hello from ELB");
 	}
 
@@ -1343,7 +1343,7 @@ public class FunctionInvokerTests {
 		JsonMapper mapper = new JacksonMapper(new ObjectMapper());
 
 		String result = new String(output.toByteArray(), StandardCharsets.UTF_8);
-		Map resultMap = mapper.fromJson(result, Map.class);
+		Map<String, Object> resultMap = mapper.fromJson(result, Map.class);
 		assertThat((boolean) resultMap.get(AWSLambdaUtils.IS_BASE64_ENCODED)).isTrue();
 		assertThat((int) resultMap.get(AWSLambdaUtils.STATUS_CODE)).isEqualTo(201);
 		String body = new String(Base64.getDecoder().decode((String) resultMap.get(AWSLambdaUtils.BODY)), StandardCharsets.UTF_8);
@@ -1476,7 +1476,7 @@ public class FunctionInvokerTests {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		invoker.handleRequest(targetStream, output, null);
 
-		Map result = mapper.readValue(output.toByteArray(), Map.class);
+		Map<String, Object> result = mapper.readValue(output.toByteArray(), Map.class);
 		assertThat(result.get("body")).isNull();
 		assertThat(result.get("principalId")).isNotNull();
 	}
@@ -1563,9 +1563,7 @@ public class FunctionInvokerTests {
 	public static class BasicConfiguration {
 		@Bean
 		public Function<Message<String>, Message<String>> uppercase() {
-			return v -> {
-				return MessageBuilder.withPayload(v.getPayload().toUpperCase(Locale.ROOT)).build();
-			};
+			return v -> MessageBuilder.withPayload(v.getPayload().toUpperCase(Locale.ROOT)).build();
 		}
 	}
 
@@ -1574,7 +1572,7 @@ public class FunctionInvokerTests {
 	public static class AuthorizerConfiguration {
 		@Bean
 		public Function<APIGatewayCustomAuthorizerEvent, String> acceptAuthorizerEvent() {
-			return v -> v.toString();
+			return Object::toString;
 		}
 	}
 
@@ -1753,9 +1751,7 @@ public class FunctionInvokerTests {
 
 		@Bean
 		public Function<S3Event, S3Event> outputS3Event() {
-			return v -> {
-				return v;
-			};
+			return v -> v;
 		}
 		@Bean
 		public Function<String, String> echoString() {
@@ -1858,7 +1854,7 @@ public class FunctionInvokerTests {
 
 		@Bean
 		public Consumer<String> consume() {
-			return v -> System.out.println(v);
+			return System.out::println;
 		}
 
 		@Bean
@@ -1873,9 +1869,7 @@ public class FunctionInvokerTests {
 
 		@Bean
 		public Function<Person, String> uppercasePojo() {
-			return v -> {
-				return v.getName().toUpperCase(Locale.ROOT);
-			};
+			return v -> v.getName().toUpperCase(Locale.ROOT);
 		}
 
 		@Bean
@@ -1898,9 +1892,7 @@ public class FunctionInvokerTests {
 
 		@Bean
 		public Function<APIGatewayProxyRequestEvent, String> inputApiEvent() {
-			return v -> {
-				return v.getBody();
-			};
+			return APIGatewayProxyRequestEvent::getBody;
 		}
 
 		@Bean
@@ -1962,16 +1954,12 @@ public class FunctionInvokerTests {
 
 		@Bean
 		public Function<APIGatewayV2HTTPEvent, String> inputApiV2Event() {
-			return v -> {
-				return v.getBody();
-			};
+			return APIGatewayV2HTTPEvent::getBody;
 		}
 
 		@Bean
 		public Function<Message<APIGatewayProxyRequestEvent>, String> inputApiEventAsMessage() {
-			return v -> {
-				return v.getPayload().getBody();
-			};
+			return v -> v.getPayload().getBody();
 		}
 
 		@Bean
@@ -2006,9 +1994,7 @@ public class FunctionInvokerTests {
 	public static class PrimitiveConfiguration {
 		@Bean
 		public Function<Message<byte[]>, byte[]> returnByteArrayAsMessage() {
-			return v -> {
-				return v.getPayload();
-			};
+			return Message::getPayload;
 		}
 	}
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/AzureWebProxyInvokerTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/AzureWebProxyInvokerTests.java
@@ -37,7 +37,7 @@ public class AzureWebProxyInvokerTests {
 		AzureWebProxyInvoker proxyInvoker = new AzureWebProxyInvoker();
 		AzureWebProxyInvoker instance = proxyInvoker.getInstance(AzureWebProxyInvoker.class);
 
-		HttpRequestMessageStub<Optional<String>> request = new HttpRequestMessageStub<Optional<String>>();
+		HttpRequestMessageStub<Optional<String>> request = new HttpRequestMessageStub<>();
 
 		request.setHttpMethod(HttpMethod.GET);
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/PetStoreSpringAppConfig.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure-web/src/test/java/org/springframework/cloud/function/adapter/azure/web/PetStoreSpringAppConfig.java
@@ -16,13 +16,7 @@
 
 package org.springframework.cloud.function.adapter.azure.web;
 
-import java.io.IOException;
-
 import jakarta.servlet.Filter;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -57,13 +51,9 @@ public class PetStoreSpringAppConfig {
 
 	@Bean
 	public Filter filter() {
-		return new Filter() {
-			@Override
-			public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-					throws IOException, ServletException {
-				System.out.println("FILTER ===> Hello from: " + request.getLocalAddr());
-				chain.doFilter(request, response);
-			}
+		return (request, response, chain) -> {
+			System.out.println("FILTER ===> Hello from: " + request.getLocalAddr());
+			chain.doFilter(request, response);
 		};
 	}
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/main/java/org/springframework/cloud/function/adapter/azure/AzureFunctionUtil.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/main/java/org/springframework/cloud/function/adapter/azure/AzureFunctionUtil.java
@@ -67,9 +67,7 @@ public final class AzureFunctionUtil {
 					.setHeaderIfAbsent(EXECUTION_CONTEXT, executionContext).build();
 		}
 		else if (input instanceof Iterable) {
-			return Flux.fromIterable((Iterable) input).map(item -> {
-				return constructInputMessageFromItem(item, executionContext);
-			});
+			return Flux.fromIterable((Iterable) input).map(item -> constructInputMessageFromItem(item, executionContext));
 		}
 		return constructInputMessageFromItem(input, executionContext);
 	}
@@ -95,7 +93,7 @@ public final class AzureFunctionUtil {
 	}
 
 	private static <I> MessageHeaders getHeaders(HttpRequestMessage<I> event) {
-		Map<String, Object> headers = new HashMap<String, Object>();
+		Map<String, Object> headers = new HashMap<>();
 
 		if (event.getHeaders() != null) {
 			headers.putAll(event.getHeaders());

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/injector/AzureFunctionInstanceInjectorTest.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/injector/AzureFunctionInstanceInjectorTest.java
@@ -63,7 +63,7 @@ public class AzureFunctionInstanceInjectorTest {
 
 		Assertions.assertThat(azureFunction).isNotNull();
 
-		HttpRequestMessageStub<Optional<String>> requestStub = new HttpRequestMessageStub<Optional<String>>();
+		HttpRequestMessageStub<Optional<String>> requestStub = new HttpRequestMessageStub<>();
 
 		requestStub.setBody(Optional.of("payload"));
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/injector/FunctionInstanceInjectorServiceLoadingTest.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-azure/src/test/java/org/springframework/cloud/function/adapter/azure/injector/FunctionInstanceInjectorServiceLoadingTest.java
@@ -64,7 +64,7 @@ public class FunctionInstanceInjectorServiceLoadingTest {
 
 		MyAzureTestFunction functionInstance = injector.getInstance(MyAzureTestFunction.class);
 
-		HttpRequestMessageStub<Optional<String>> request = new HttpRequestMessageStub<Optional<String>>();
+		HttpRequestMessageStub<Optional<String>> request = new HttpRequestMessageStub<>();
 
 		request.setBody(Optional.of("test"));
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/main/java/org/springframework/cloud/function/adapter/gcp/FunctionInvoker.java
@@ -180,7 +180,7 @@ public class FunctionInvoker implements HttpFunction, RawBackgroundFunction {
 			httpResponse.setContentType(result.getHeaders().get("Content-Type").toString());
 		}
 		else {
-			httpRequest.getContentType().ifPresent(contentType -> httpResponse.setContentType(contentType));
+			httpRequest.getContentType().ifPresent(httpResponse::setContentType);
 		}
 		String content = result.getPayload() instanceof String strPayload ? strPayload
 				: new String((byte[]) result.getPayload(), StandardCharsets.UTF_8);
@@ -188,7 +188,7 @@ public class FunctionInvoker implements HttpFunction, RawBackgroundFunction {
 		for (Entry<String, Object> header : headers.entrySet()) {
 			Object values = header.getValue();
 			if (values instanceof Collection<?>) {
-				String headerValue = ((Collection<?>) values).stream().map(item -> item.toString())
+				String headerValue = ((Collection<?>) values).stream().map(Object::toString)
 						.collect(Collectors.joining(","));
 				httpResponse.appendHeader(header.getKey(), headerValue);
 			}

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerHttpTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/FunctionInvokerHttpTests.java
@@ -249,7 +249,7 @@ public class FunctionInvokerHttpTests {
 		public Function<String, Message<String>> function() {
 
 			String payload = "hello";
-			List<Object> li = new ArrayList<Object>(asList(123, "headerThing"));
+			List<Object> li = new ArrayList<>(asList(123, "headerThing"));
 
 			Message<String> msg = MessageBuilder.withPayload(payload).setHeader("multiValueHeader", li)
 				.build();
@@ -298,11 +298,9 @@ public class FunctionInvokerHttpTests {
 
 		@Bean
 		public Function<IncomingRequest, Message<OutgoingResponse>> function() {
-			return (in) -> {
-				return MessageBuilder
+			return (in) -> MessageBuilder
 						.withPayload(new OutgoingResponse("Thank you for sending the message: " + in.message))
 						.setHeader("foo", "bar").build();
-			};
 		}
 	}
 

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/FunctionInvokerIntegrationTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/FunctionInvokerIntegrationTests.java
@@ -70,7 +70,7 @@ public class FunctionInvokerIntegrationTests {
 
 			HttpHeaders headers = new HttpHeaders();
 			ResponseEntity<String> response = testRestTemplate.postForEntity(
-					"http://localhost:" + serverProcess.getPort(), new HttpEntity<>("test", headers),
+					"http://localhost:" + serverProcess.port(), new HttpEntity<>("test", headers),
 					String.class);
 
 			assertThat(response.getStatusCode().is5xxServerError()).isTrue();

--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-gcp/src/test/java/org/springframework/cloud/function/adapter/gcp/integration/LocalServerTestSupport.java
@@ -74,7 +74,7 @@ final public class LocalServerTestSupport {
 			HttpHeaders headers = new HttpHeaders();
 
 			ResponseEntity<String> response = testRestTemplate.postForEntity(
-					"http://localhost:" + serverProcess.getPort(), new HttpEntity<>(gson.toJson(input), headers),
+					"http://localhost:" + serverProcess.port(), new HttpEntity<>(gson.toJson(input), headers),
 					String.class);
 
 			assertThat(response.getBody()).isEqualTo(gson.toJson(expectedOutput));
@@ -148,28 +148,11 @@ final public class LocalServerTestSupport {
 		throw new RuntimeException("End of input stream and server never became ready");
 	}
 
-	static class ServerProcess implements AutoCloseable {
-
-		private final Process process;
-
-		private final int port;
-
-		ServerProcess(Process process, int port) {
-			this.process = process;
-			this.port = port;
-		}
-
-		Process process() {
-			return process;
-		}
+	record ServerProcess(Process process, int port) implements AutoCloseable {
 
 		@Override
 		public void close() {
 			process().destroy();
-		}
-
-		public int getPort() {
-			return port;
 		}
 
 	}

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcAutoConfiguration.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcAutoConfiguration.java
@@ -65,7 +65,7 @@ public class GrpcAutoConfiguration {
 	@Bean
 	public MessageHandlingHelper grpcMessageHandlingHelper(List<GrpcMessageConverter<?>> grpcConverters,
 			FunctionProperties funcProperties, FunctionCatalog functionCatalog) {
-		return new MessageHandlingHelper(grpcConverters, functionCatalog, funcProperties);
+		return new MessageHandlingHelper<>(grpcConverters, functionCatalog, funcProperties);
 	}
 
 	@Bean

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcSpringMessageConverter.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcSpringMessageConverter.java
@@ -43,9 +43,7 @@ public class GrpcSpringMessageConverter extends AbstractGrpcMessageConverter<Grp
 	@Override
 	protected GrpcSpringMessage doFromSpringMessage(Message<byte[]> springMessage) {
 		Map<String, String> stringHeaders = new HashMap<>();
-		springMessage.getHeaders().forEach((k, v) -> {
-			stringHeaders.put(k, v.toString());
-		});
+		springMessage.getHeaders().forEach((k, v) -> stringHeaders.put(k, v.toString()));
 		return GrpcSpringMessage.newBuilder()
 				.setPayload(ByteString.copyFrom(springMessage.getPayload()))
 				.putAllHeaders(stringHeaders)

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcUtils.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/GrpcUtils.java
@@ -64,9 +64,7 @@ public final class GrpcUtils {
 
 	public static GrpcSpringMessage toGrpcSpringMessage(Message<byte[]> message) {
 		Map<String, String> stringHeaders = new HashMap<>();
-		message.getHeaders().forEach((k, v) -> {
-			stringHeaders.put(k, v.toString());
-		});
+		message.getHeaders().forEach((k, v) -> stringHeaders.put(k, v.toString()));
 		return toGrpcSpringMessage(message.getPayload(), stringHeaders);
 	}
 
@@ -201,7 +199,7 @@ public final class GrpcUtils {
 				.usePlaintext().build();
 
 		LinkedBlockingQueue<Message<byte[]>> resultRef = new LinkedBlockingQueue<>(1);
-		StreamObserver<GrpcSpringMessage> responseObserver = new StreamObserver<GrpcSpringMessage>() {
+		StreamObserver<GrpcSpringMessage> responseObserver = new StreamObserver<>() {
 			@Override
 			public void onNext(GrpcSpringMessage result) {
 				if (logger.isDebugEnabled()) {
@@ -237,9 +235,7 @@ public final class GrpcUtils {
 			catch (Exception e) {
 				requestObserver.onError(e);
 			}
-		}).doOnComplete(() -> {
-			requestObserver.onCompleted();
-		}).doOnError(e -> {
+		}).doOnComplete(requestObserver::onCompleted).doOnError(e -> {
 			e.printStackTrace();
 			responseObserver.onError(Status.UNKNOWN.withDescription("Error handling request")
 					.withCause(e).asRuntimeException());
@@ -256,7 +252,7 @@ public final class GrpcUtils {
 	}
 
 	private static ClientResponseObserver<GrpcSpringMessage, GrpcSpringMessage> clientResponseObserver(Flux<Message<byte[]>> inputStream, Many<Message<byte[]>> sink) {
-		return new ClientResponseObserver<GrpcSpringMessage, GrpcSpringMessage>() {
+		return new ClientResponseObserver<>() {
 
 			ClientCallStreamObserver<GrpcSpringMessage> requestStreamObserver;
 
@@ -265,22 +261,15 @@ public final class GrpcUtils {
 				this.requestStreamObserver = requestStreamObserver;
 				requestStreamObserver.disableAutoInboundFlowControl();
 
-				requestStreamObserver.setOnReadyHandler(new Runnable() {
-					@Override
-					public void run() {
-						inputStream
-						.doOnNext(request -> {
-							if (logger.isDebugEnabled()) {
-								logger.debug("Streaming message to function: " + request);
-							}
-							requestStreamObserver.onNext(GrpcUtils.toGrpcSpringMessage(request));
-						})
-						.doOnComplete(() -> {
-							requestStreamObserver.onCompleted();
-						})
-						.subscribe();
-					}
-				});
+				requestStreamObserver.setOnReadyHandler(() -> inputStream
+					.doOnNext(request -> {
+						if (logger.isDebugEnabled()) {
+							logger.debug("Streaming message to function: " + request);
+						}
+						requestStreamObserver.onNext(GrpcUtils.toGrpcSpringMessage(request));
+					})
+						.doOnComplete(requestStreamObserver::onCompleted)
+					.subscribe());
 			}
 
 			@Override

--- a/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/MessageHandlingHelper.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-grpc/src/main/java/org/springframework/cloud/function/grpc/MessageHandlingHelper.java
@@ -108,10 +108,8 @@ public class MessageHandlingHelper<T extends GeneratedMessageV3> implements Smar
 		Message<byte[]> message = this.toSpringMessage(request);
 		FunctionInvocationWrapper function = this.resolveFunction(message.getHeaders());
 		Publisher<Message<byte[]>> replyStream = (Publisher<Message<byte[]>>) function.apply(message);
-		Flux.from(replyStream).doOnNext(replyMessage -> {
-			responseObserver.onNext(this.toGrpcMessage(replyMessage, (Class<T>) request.getClass()));
-		})
-		.doOnComplete(() -> responseObserver.onCompleted())
+		Flux.from(replyStream).doOnNext(replyMessage -> responseObserver.onNext(this.toGrpcMessage(replyMessage, (Class<T>) request.getClass())))
+		.doOnComplete(responseObserver::onCompleted)
 		.subscribe();
 	}
 
@@ -154,7 +152,7 @@ public class MessageHandlingHelper<T extends GeneratedMessageV3> implements Smar
 				resultRef.offer(replyMessage);
 			});
 
-			return new StreamObserver<T>() {
+			return new StreamObserver<>() {
 				@Override
 				public void onNext(T inputMessage) {
 					if (logger.isDebugEnabled()) {
@@ -245,7 +243,7 @@ public class MessageHandlingHelper<T extends GeneratedMessageV3> implements Smar
 			responseObserver.onNext(outputMessage);
 		});
 
-		return new StreamObserver<T>() {
+		return new StreamObserver<>() {
 			@Override
 			public void onNext(T inputMessage) {
 				if (logger.isDebugEnabled()) {
@@ -275,7 +273,7 @@ public class MessageHandlingHelper<T extends GeneratedMessageV3> implements Smar
 	private StreamObserver<T> biStreamImperative(StreamObserver<T> responseObserver,
 			ServerCallStreamObserver<T> serverCallStreamObserver,
 			AtomicBoolean wasReady) {
-		return new StreamObserver<T>() {
+		return new StreamObserver<>() {
 
 			@SuppressWarnings("unchecked")
 			@Override

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessMVC.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessMVC.java
@@ -399,7 +399,7 @@ public final class ServerlessMVC {
 
 		@Override
 		public Enumeration<String> getInitParameterNames() {
-			return Collections.enumeration(new ArrayList<String>());
+			return Collections.enumeration(new ArrayList<>());
 		}
 
 		@Override

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessServletContext.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessServletContext.java
@@ -64,7 +64,7 @@ public class ServerlessServletContext implements ServletContext {
 
 	private final Map<String, FilterRegistration> filterRegistrations = new HashMap<>();
 
-	private static final Enumeration<String> EMPTY_ENUM = Collections.enumeration(new ArrayList<String>());
+	private static final Enumeration<String> EMPTY_ENUM = Collections.enumeration(new ArrayList<>());
 
 	@Override
 	public Enumeration<String> getInitParameterNames() {

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessWebApplication.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessWebApplication.java
@@ -235,13 +235,7 @@ public class ServerlessWebApplication extends SpringApplication {
 		}
 	}
 
-	private static class PropertySourceOrderingBeanFactoryPostProcessor implements BeanFactoryPostProcessor, Ordered {
-
-		private final ConfigurableApplicationContext context;
-
-		PropertySourceOrderingBeanFactoryPostProcessor(ConfigurableApplicationContext context) {
-			this.context = context;
-		}
+	private record PropertySourceOrderingBeanFactoryPostProcessor(ConfigurableApplicationContext context) implements BeanFactoryPostProcessor, Ordered {
 
 		@Override
 		public int getOrder() {
@@ -250,7 +244,7 @@ public class ServerlessWebApplication extends SpringApplication {
 
 		@Override
 		public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
-			DefaultPropertiesPropertySource.moveToEnd(this.context.getEnvironment());
+			DefaultPropertiesPropertySource.moveToEnd(this.context().getEnvironment());
 		}
 
 	}
@@ -307,21 +301,12 @@ public class ServerlessWebApplication extends SpringApplication {
 		 * Decorator that allows a {@link Banner} to be printed again without needing to
 		 * specify the source class.
 		 */
-		private static class PrintedBanner implements Banner {
-
-			private final Banner banner;
-
-			private final Class<?> sourceClass;
-
-			PrintedBanner(Banner banner, Class<?> sourceClass) {
-				this.banner = banner;
-				this.sourceClass = sourceClass;
-			}
+		private record PrintedBanner(Banner banner, Class<?> sourceClass) implements Banner {
 
 			@Override
 			public void printBanner(Environment environment, Class<?> sourceClass, PrintStream out) {
-				sourceClass = (sourceClass != null) ? sourceClass : this.sourceClass;
-				this.banner.printBanner(environment, sourceClass, out);
+				sourceClass = (sourceClass != null) ? sourceClass : this.sourceClass();
+				this.banner().printBanner(environment, sourceClass, out);
 			}
 
 		}

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/serverless/web/RequestResponseTests.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/serverless/web/RequestResponseTests.java
@@ -99,7 +99,7 @@ public class RequestResponseTests {
 		HttpServletRequest request = new ServerlessHttpServletRequest(null, "GET", "/pets");
 		ServerlessHttpServletResponse response = new ServerlessHttpServletResponse();
 		mvc.service(request, response);
-		TypeReference<List<Pet>> tr = new TypeReference<List<Pet>>() {
+		TypeReference<List<Pet>> tr = new TypeReference<>() {
 		};
 		List<Pet> pets = mapper.readValue(response.getContentAsByteArray(), tr);
 		assertThat(pets.size()).isEqualTo(10);
@@ -112,7 +112,7 @@ public class RequestResponseTests {
 		request.setParameter("limit", "5");
 		ServerlessHttpServletResponse response = new ServerlessHttpServletResponse();
 		mvc.service(request, response);
-		TypeReference<List<Pet>> tr = new TypeReference<List<Pet>>() {
+		TypeReference<List<Pet>> tr = new TypeReference<>() {
 		};
 		List<Pet> pets = mapper.readValue(response.getContentAsByteArray(), tr);
 		assertThat(pets.size()).isEqualTo(5);

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/test/app/PetStoreSpringAppConfig.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/test/app/PetStoreSpringAppConfig.java
@@ -36,6 +36,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -80,8 +82,8 @@ public class PetStoreSpringAppConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http, SimpleFilter simpleFilter,
 			AnotherFilter anotherFilter) throws Exception {
 		http
-		.csrf(csrf -> csrf.disable())
-		.cors(cors -> cors.disable())
+		.csrf(CsrfConfigurer::disable)
+		.cors(CorsConfigurer::disable)
 		.addFilterBefore(new GenericFilterBean() {
 			@Override
 			public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -95,9 +97,7 @@ public class PetStoreSpringAppConfig {
 			}
 		}, SecurityContextHolderFilter.class)
 		.securityMatcher("/foo/deny")
-		.authorizeHttpRequests(auth -> {
-			auth.anyRequest().hasRole("FOO");
-		})
+		.authorizeHttpRequests(auth -> auth.anyRequest().hasRole("FOO"))
 		.addFilterAfter(simpleFilter, LogoutFilter.class)
 		.addFilterAfter(anotherFilter, RequestCacheAwareFilter.class)
 		.exceptionHandling(f -> f.accessDeniedHandler(new MyAccessDeinedHandler()));

--- a/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/test/app/PetsController.java
+++ b/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/test/java/org/springframework/cloud/function/test/app/PetsController.java
@@ -45,7 +45,7 @@ public class PetsController {
 
 		Pet dbPet = newPet;
 		dbPet.setId(UUID.randomUUID().toString());
-		DeferredResult<Pet> result = new DeferredResult<Pet>();
+		DeferredResult<Pet> result = new DeferredResult<>();
 		result.setResult(dbPet);
 		return result;
 	}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventMessageBuilder.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventMessageBuilder.java
@@ -55,13 +55,13 @@ public final class CloudEventMessageBuilder<T> {
 	}
 
 	public static <T> CloudEventMessageBuilder<T> withData(T data) {
-		CloudEventMessageBuilder<T> builder = new CloudEventMessageBuilder<T>(null);
+		CloudEventMessageBuilder<T> builder = new CloudEventMessageBuilder<>(null);
 		builder.data = data;
 		return builder;
 	}
 
 	public static <T> CloudEventMessageBuilder<T> fromMessage(Message<T> message) {
-		CloudEventMessageBuilder<T> builder = new CloudEventMessageBuilder<T>(new HashMap<>(message.getHeaders()));
+		CloudEventMessageBuilder<T> builder = new CloudEventMessageBuilder<>(new HashMap<>(message.getHeaders()));
 		builder.data = message.getPayload();
 		return builder;
 	}
@@ -211,7 +211,7 @@ public final class CloudEventMessageBuilder<T> {
 			this.headers.put(prefix + CloudEventMessageUtils._SOURCE, URI.create("https://spring.io/"));
 		}
 		MessageHeaders headers = new MessageHeaders(this.headers);
-		GenericMessage<T> message = new GenericMessage<T>(this.data, headers);
+		GenericMessage<T> message = new GenericMessage<>(this.data, headers);
 		Assert.isTrue(CloudEventMessageUtils.isCloudEvent(message), "The message does not appear to be a valid Cloud Event, "
 				+ "since one of the required attributes (id, specversion, type, source) is missing");
 		return message;

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtils.java
@@ -246,7 +246,7 @@ public final class CloudEventMessageUtils {
 	public static Map<String, Object> getAttributes(Message<?> message) {
 		return message.getHeaders().entrySet().stream()
 				.filter(e -> isAttribute(e.getKey()))
-				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	/**
@@ -483,8 +483,8 @@ public final class CloudEventMessageUtils {
 	private static URI safeGetURI(Map<String, Object> map, String key) {
 		Object uri = map.get(key);
 		if (uri != null) {
-			if (uri instanceof String) {
-				uri = URI.create((String) uri);
+			if (uri instanceof String s) {
+				uri = URI.create(s);
 			}
 			else if (uri instanceof byte[] u) {
 				uri = URI.create(toString(u));

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionInvocationHelper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionInvocationHelper.java
@@ -101,7 +101,7 @@ public class CloudEventsFunctionInvocationHelper implements FunctionInvocationHe
 		if (input != null) {
 			targetPrefix = CloudEventMessageUtils.determinePrefixToUse(input.getHeaders(), true);
 		}
-		else if (result instanceof Message resultMessage) {
+		else if (result instanceof Message<?> resultMessage) {
 			targetPrefix = CloudEventMessageUtils.determinePrefixToUse(resultMessage.getHeaders(), true);
 		}
 

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionProperties.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionProperties.java
@@ -133,12 +133,12 @@ public class FunctionProperties implements EnvironmentAware, ApplicationContextA
 		Map<String, Object>  headerMapping = input ? entry.getValue().getInputHeaderMappingExpression()
 				: entry.getValue().getOutputHeaderMappingExpression();
 		if (!CollectionUtils.isEmpty(headerMapping)) {
-			for (Object k : headerMapping.keySet()) {
+			for (String k : headerMapping.keySet()) {
 				if (this.environment.containsProperty(propertyX + k) || this.environment.containsProperty(propertyY + k)) {
-					Map current = input ? entry.getValue().getInputHeaderMappingExpression()
+					Map<String, Object> current = input ? entry.getValue().getInputHeaderMappingExpression()
 									: entry.getValue().getOutputHeaderMappingExpression();
 					if (current.containsKey("0")) {
-						((Map) current.get("0")).put(k, headerMapping.get(k));
+						((Map<String, Object>) current.get("0")).put(k, headerMapping.get(k));
 					}
 					else {
 						if (input) {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionTypeProcessor.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionTypeProcessor.java
@@ -72,8 +72,8 @@ public class FunctionTypeProcessor implements BeanFactoryInitializationAotProces
 			if (!isCoreJavaType(name)) {
 				typeHints.add(FunctionTypeUtils.getRawType(functionParameterType));
 			}
-			if (functionParameterType instanceof ParameterizedType) {
-				this.registerAllGenericTypes((ParameterizedType) functionParameterType, typeHints);
+			if (functionParameterType instanceof ParameterizedType parameterizedType) {
+				this.registerAllGenericTypes(parameterizedType, typeHints);
 			}
 		}
 	}
@@ -88,13 +88,7 @@ public class FunctionTypeProcessor implements BeanFactoryInitializationAotProces
 					|| Supplier.class.isAssignableFrom(beanType);
 	}
 
-	private static final class ReflectiveProcessorBeanFactoryInitializationAotContribution implements BeanFactoryInitializationAotContribution {
-
-		private final Class<?>[] typeHints;
-
-		private ReflectiveProcessorBeanFactoryInitializationAotContribution(Class<?>[] typeHints) {
-			this.typeHints = typeHints;
-		}
+	private record ReflectiveProcessorBeanFactoryInitializationAotContribution(Class<?>[] typeHints) implements BeanFactoryInitializationAotContribution {
 
 		@Override
 		public void applyTo(GenerationContext generationContext, BeanFactoryInitializationCode beanFactoryInitializationCode) {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionalSpringApplication.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionalSpringApplication.java
@@ -99,8 +99,7 @@ public class FunctionalSpringApplication
 			System.out.println("======> SOURCE: " + source);
 			Class<?> type = null;
 			Object handler = null;
-			if (source instanceof String) {
-				String name = (String) source;
+			if (source instanceof String name) {
 				if (ClassUtils.isPresent(name, null)) {
 					type = ClassUtils.resolveClassName(name, null);
 				}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistry.java
@@ -31,7 +31,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.aopalliance.intercept.MethodInterceptor;
-import org.aopalliance.intercept.MethodInvocation;
 
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.BeansException;
@@ -165,8 +164,8 @@ public class BeanFactoryAwareFunctionRegistry extends SimpleFunctionRegistry imp
 						if (functionCandidate != null) {
 							Type functionType = null;
 							FunctionRegistration functionRegistration = null;
-							if (functionCandidate instanceof FunctionRegistration) {
-								functionRegistration = (FunctionRegistration) functionCandidate;
+							if (functionCandidate instanceof FunctionRegistration registration) {
+								functionRegistration = registration;
 							}
 							else if (functionCandidate instanceof BiFunction || functionCandidate instanceof BiConsumer) {
 								functionRegistration = this.registerMessagingBiFunction(functionCandidate, functionName);
@@ -223,9 +222,9 @@ public class BeanFactoryAwareFunctionRegistry extends SimpleFunctionRegistry imp
 		Type biFunctionType = FunctionContextUtils.findType(this.applicationContext.getBeanFactory(), functionName);
 		Type inputType1 = Object.class;
 		Type inputType2 = Object.class;
-		if (biFunctionType instanceof ParameterizedType) {
-			inputType1 = ((ParameterizedType) biFunctionType).getActualTypeArguments()[0];
-			inputType2 = ((ParameterizedType) biFunctionType).getActualTypeArguments()[1];
+		if (biFunctionType instanceof ParameterizedType parameterizedType) {
+			inputType1 = parameterizedType.getActualTypeArguments()[0];
+			inputType2 = parameterizedType.getActualTypeArguments()[1];
 		}
 
 		if (!FunctionTypeUtils.isTypeMap(inputType2)) {
@@ -242,8 +241,8 @@ public class BeanFactoryAwareFunctionRegistry extends SimpleFunctionRegistry imp
 			if (payload.getClass().getName().equals("org.springframework.kafka.support.KafkaNull")) {
 				payload = null;
 			}
-			if (userFunction instanceof BiConsumer) {
-				((BiConsumer) userFunction).accept(payload, ((Message) message).getHeaders());
+			if (userFunction instanceof BiConsumer biConsumer) {
+				biConsumer.accept(payload, ((Message) message).getHeaders());
 				return null;
 			}
 			else {
@@ -304,12 +303,7 @@ public class BeanFactoryAwareFunctionRegistry extends SimpleFunctionRegistry imp
 		ProxyFactory pf = new ProxyFactory(targetFunction);
 		pf.setProxyTargetClass(true);
 		pf.setInterfaces(Function.class);
-		pf.addAdvice(new MethodInterceptor() {
-			@Override
-			public Object invoke(MethodInvocation invocation) throws Throwable {
-				return actualMethodToCall.invoke(invocation.getThis(), invocation.getArguments());
-			}
-		});
+		pf.addAdvice((MethodInterceptor) invocation -> actualMethodToCall.invoke(invocation.getThis(), invocation.getArguments()));
 		return pf.getProxy();
 	}
 }

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtils.java
@@ -116,7 +116,7 @@ public final class FunctionTypeUtils {
 	 * @return 'true' if this type represents a {@link Collection}. Otherwise 'false'.
 	 */
 	public static boolean isTypeCollection(Type type) {
-		Class rawClass = getRawType(type);
+		Class<?> rawClass = getRawType(type);
 		if (rawClass == null) {
 			return false;
 		}
@@ -170,8 +170,8 @@ public final class FunctionTypeUtils {
 	 * @return instance of {@link Class} as raw representation of the provided {@link Type}
 	 */
 	public static Class<?> getRawType(Type type) {
-		if (type instanceof WildcardType) {
-			Type[] upperbounds = ((WildcardType) type).getUpperBounds();
+		if (type instanceof WildcardType wildcardType) {
+			Type[] upperbounds = wildcardType.getUpperBounds();
 			/*
 			 * Kotlin may have something like this <? extends Message> which is technically a whildcard yet it has upper/lower types.
 			 * See GH-1260
@@ -443,8 +443,8 @@ public final class FunctionTypeUtils {
 		if (function instanceof RoutingFunction) {
 			return ROUTING_FUNCTION_TYPE;
 		}
-		else if (function instanceof FunctionRegistration) {
-			return ((FunctionRegistration) function).getType();
+		else if (function instanceof FunctionRegistration registration) {
+			return registration.getType();
 		}
 		if (applicationContext.containsBean(functionName + FunctionRegistration.REGISTRATION_NAME_SUFFIX)) { // for Kotlin primarily
 			FunctionRegistration fr = applicationContext
@@ -498,8 +498,8 @@ public final class FunctionTypeUtils {
 		return null;
 	}
 	public static Type getImmediateGenericType(Type type, int index) {
-		if (type instanceof ParameterizedType) {
-			return ((ParameterizedType) type).getActualTypeArguments()[index];
+		if (type instanceof ParameterizedType parameterizedType) {
+			return parameterizedType.getActualTypeArguments()[index];
 		}
 		return null;
 	}
@@ -615,15 +615,15 @@ public final class FunctionTypeUtils {
 		if (type instanceof Class) {
 			return cls.isAssignableFrom((Class<?>) type);
 		}
-		else if (type instanceof ParameterizedType) {
-			return isOfType(((ParameterizedType) type).getRawType(), cls);
+		else if (type instanceof ParameterizedType parameterizedType) {
+			return isOfType(parameterizedType.getRawType(), cls);
 		}
 		return false;
 	}
 
 	private static void assertSupportedTypes(Type type) {
-		if (type instanceof ParameterizedType) {
-			type = ((ParameterizedType) type).getRawType();
+		if (type instanceof ParameterizedType parameterizedType) {
+			type = parameterizedType.getRawType();
 			Assert.isTrue(type instanceof Class<?>, "Must be one of Supplier, Function, Consumer"
 					+ " or FunctionRegistration. Was " + type);
 		}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/HeaderEnricher.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/HeaderEnricher.java
@@ -52,10 +52,10 @@ class HeaderEnricher implements Function<Object, Object> {
 
 	private final StandardEvaluationContext evalContext = new StandardEvaluationContext();
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	HeaderEnricher(Map headerExpressions, @Nullable BeanResolver beanResolver) {
+	@SuppressWarnings("unchecked")
+	HeaderEnricher(Map<String, Object> headerExpressions, @Nullable BeanResolver beanResolver) {
 		Assert.notEmpty(headerExpressions, "'headerExpressions' must not be null or empty");
-		this.headerExpressions = headerExpressions;
+		this.headerExpressions = (Map<String, Map<String, String>>) (Map<?, ?>) headerExpressions;
 		this.evalContext.addPropertyAccessor(new MapAccessor());
 		if (beanResolver != null) {
 			this.evalContext.setBeanResolver(beanResolver);

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistry.java
@@ -135,7 +135,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 		this.messageConverter = messageConverter;
 		this.functionInvocationHelper = functionInvocationHelper;
 		this.functionProperties = functionProperties;
-		this.wrappedFunctionDefinitions = new LinkedHashMap<String, FunctionInvocationWrapper>() {
+		this.wrappedFunctionDefinitions = new LinkedHashMap<>() {
 			@Override
 			protected boolean removeEldestEntry(Map.Entry<String, FunctionInvocationWrapper> eldest) {
 				boolean remove = size() > wrappedFunctionDefinitionsCacheSize;
@@ -486,8 +486,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 		private boolean isPojoFunction;
 
 		FunctionInvocationWrapper(String functionDefinition,  Object target, Type inputType, Type outputType) {
-			if (target instanceof PostProcessingFunction) {
-				this.postProcessor = (PostProcessingFunction) target;
+			if (target instanceof PostProcessingFunction postProcessingFunction) {
+				this.postProcessor = postProcessingFunction;
 			}
 			if (ClassUtils.isPresent("kotlin.jvm.functions.Function0", ClassUtils.getDefaultClassLoader())
 				&& target instanceof KotlinLambdaToFunctionAutoConfiguration.KotlinFunctionWrapper kotlinFunction
@@ -940,8 +940,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 					logger.debug("Actual input represents a collection while input type of the function does not represent a collection. " +
 						"Therefore framework will attempt invoke function for each element in the collection.");
 					MessageHeaders headers = input instanceof Message ? ((Message) input).getHeaders() : new MessageHeaders(Collections.emptyMap());
-					Collection collectionPayload = jsonMapper.fromJson(payload, Collection.class);
-					Class inputClass = FunctionTypeUtils.getRawType(this.inputType);
+				Collection<?> collectionPayload = jsonMapper.fromJson(payload, Collection.class);
+				Class<?> inputClass = FunctionTypeUtils.getRawType(this.inputType);
 					if (this.isInputTypeMessage()) {
 						inputClass = FunctionTypeUtils.getRawType(FunctionTypeUtils.getImmediateGenericType(this.inputType, 0));
 					}
@@ -968,8 +968,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 						return Flux.fromIterable((Iterable) ((Message) v).getPayload());
 					});
 				}
-				else if (input instanceof Iterable) {
-					input = FunctionTypeUtils.isMono(this.inputType) ? Mono.just(input) : Flux.fromIterable((Iterable) input);
+				else if (input instanceof Iterable iterable) {
+					input = FunctionTypeUtils.isMono(this.inputType) ? Mono.just(input) : Flux.fromIterable(iterable);
 
 				}
 				else {
@@ -998,9 +998,9 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			Object result;
 			if (!this.isTypePublisher(this.inputType) && convertedInput instanceof Publisher publisherInput) {
 				result = publisherInput instanceof Mono
-						? Mono.from(publisherInput).map(value -> this.invokeFunctionAndEnrichResultIfNecessary(value))
+						? Mono.from(publisherInput).map(this::invokeFunctionAndEnrichResultIfNecessary)
 							.doOnError(ex -> logger.error("Failed to invoke function '" + this.functionDefinition + "'", (Throwable) ex))
-						: Flux.from(publisherInput).map(value -> this.invokeFunctionAndEnrichResultIfNecessary(value))
+						: Flux.from(publisherInput).map(this::invokeFunctionAndEnrichResultIfNecessary)
 							.doOnError(ex -> logger.error("Failed to invoke function '" + this.functionDefinition + "'", (Throwable) ex));
 			}
 			else {
@@ -1025,18 +1025,18 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			AtomicReference<Message<?>> firstInputMessage = new AtomicReference<>();
 
 			Object inputValue;
-			if (value instanceof Flux) {
-				inputValue = ((Flux) value).map(v -> {
-					if (v instanceof OriginalMessageHolder && firstInputMessage.get() == null) {
-						firstInputMessage.set(((OriginalMessageHolder) v).getOriginalMessage());
+			if (value instanceof Flux flux) {
+				inputValue = flux.map(v -> {
+					if (v instanceof OriginalMessageHolder originalMessageHolder && firstInputMessage.get() == null) {
+						firstInputMessage.set(originalMessageHolder.originalMessage());
 					}
 					return this.extractValueFromOriginalValueHolderIfNecessary(v);
 				});
 			}
-			else if (value instanceof Mono) {
-				inputValue = ((Mono) value).map(v -> {
-					if (v instanceof OriginalMessageHolder) {
-						firstInputMessage.set(((OriginalMessageHolder) v).getOriginalMessage());
+			else if (value instanceof Mono mono) {
+				inputValue = mono.map(v -> {
+					if (v instanceof OriginalMessageHolder originalMessageHolder) {
+						firstInputMessage.set(originalMessageHolder.originalMessage());
 					}
 					return this.extractValueFromOriginalValueHolderIfNecessary(v);
 				});
@@ -1066,7 +1066,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			}
 
 			return value instanceof OriginalMessageHolder originalMessageHolder
-					? this.enrichInvocationResultIfNecessary((originalMessageHolder).getOriginalMessage(), result)
+					? this.enrichInvocationResultIfNecessary(originalMessageHolder.originalMessage(), result)
 					: result;
 		}
 
@@ -1114,7 +1114,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 				if (convertedInput instanceof Flux fluxInput) {
 					result = fluxInput
 							.transform(flux -> {
-								flux =  Flux.from((Publisher) flux).map(v -> this.extractValueFromOriginalValueHolderIfNecessary(v));
+								flux =  Flux.from((Publisher) flux).map(this::extractValueFromOriginalValueHolderIfNecessary);
 								((Consumer) this.target).accept(flux);
 								return Mono.ignoreElements((Flux) flux);
 							}).then();
@@ -1122,7 +1122,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 				else {
 					result = ((Mono) convertedInput)
 							.transform(mono -> {
-								mono =  Mono.from((Publisher) mono).map(v -> this.extractValueFromOriginalValueHolderIfNecessary(v));
+								mono =  Mono.from((Publisher) mono).map(this::extractValueFromOriginalValueHolderIfNecessary);
 								((Consumer) this.target).accept(mono);
 								return Mono.ignoreElements((Mono) mono);
 							}).then();
@@ -1131,10 +1131,10 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			else if (convertedInput instanceof Publisher publisherInput) {
 				result = convertedInput instanceof Mono
 						? Mono.from(publisherInput)
-								.map(v -> this.extractValueFromOriginalValueHolderIfNecessary(v))
+								.map(this::extractValueFromOriginalValueHolderIfNecessary)
 								.doOnNext((Consumer) this.target).then()
 						: Flux.from(publisherInput)
-								.map(v -> this.extractValueFromOriginalValueHolderIfNecessary(v))
+								.map(this::extractValueFromOriginalValueHolderIfNecessary)
 								.doOnNext((Consumer) this.target).then();
 			}
 			else {
@@ -1145,8 +1145,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 		}
 
 		private Object extractValueFromOriginalValueHolderIfNecessary(Object input) {
-			if (input instanceof OriginalMessageHolder) {
-				input = ((OriginalMessageHolder) input).getValue();
+			if (input instanceof OriginalMessageHolder originalMessageHolder) {
+				input = originalMessageHolder.value();
 			}
 			return input;
 		}
@@ -1171,10 +1171,10 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 		private boolean isInputConversionNecessary(Object input, Type type) {
 			if (type == null || this.getRawClassFor(type) == Void.class || this.target instanceof RoutingFunction || this.isComposed() || this.target instanceof PassThruFunction) {
 				if (this.getRawClassFor(type) == Void.class) {
-					if (input instanceof Message) {
-						input = ((Message) input).getPayload();
-						if (input instanceof Optional) {
-							input = ((Optional) input).orElseGet(() -> null);
+					if (input instanceof Message<?> messageResult) {
+						input = messageResult.getPayload();
+						if (input instanceof Optional optional) {
+							input = optional.orElseGet(() -> null);
 						}
 					}
 					Assert.isNull(input, "Can't have non-null input with Void input type.");
@@ -1184,16 +1184,18 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			return true;
 		}
 		/*
-		 *
+		 * The input variable is reassigned within the block, so casts after the reassignment
+		 * cannot be replaced with pattern matching.
 		 */
+		@SuppressWarnings("PMD.PreferPatternMatchingForInstanceof")
 		private Object convertInputIfNecessary(Object input, Type type) {
 			if (!this.isInputConversionNecessary(input, type)) {
 				return input;
 			}
 
 			Object convertedInput = null;
-			if (input instanceof Publisher) {
-				convertedInput = this.convertInputPublisherIfNecessary((Publisher) input, type);
+			if (input instanceof Publisher publisher) {
+				convertedInput = this.convertInputPublisherIfNecessary(publisher, type);
 			}
 			else if (FunctionTypeUtils.isMultipleArgumentType(type)) {
 				Type[] inputTypes = ((ParameterizedType) type).getActualTypeArguments();
@@ -1213,8 +1215,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 						? input
 						: new OriginalMessageHolder(((Message) input).getPayload(), (Message<?>) input);
 			}
-			else if (input instanceof Message) {
-				input = this.filterOutHeaders((Message) input);
+			else if (input instanceof Message messageResult) {
+				input = this.filterOutHeaders(messageResult);
 				if (((Message) input).getPayload().getClass().getName().equals("org.springframework.kafka.support.KafkaNull")) {
 					return input;
 				}
@@ -1298,8 +1300,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 				return convertedOutput;
 			}
 
-			if (convertedOutput instanceof Publisher) {
-				return this.convertOutputPublisherIfNecessary((Publisher) convertedOutput, type, contentType);
+			if (convertedOutput instanceof Publisher publisher) {
+				return this.convertOutputPublisherIfNecessary(publisher, type, contentType);
 			}
 
 			if (convertedOutput instanceof Message) {
@@ -1316,8 +1318,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			}
 			if (this.getTarget() instanceof PassThruFunction) { // scst-2303
 				Message enrichedMessage;
-				if (convertedOutput instanceof Message) {
-					enrichedMessage = MessageBuilder.fromMessage((Message) convertedOutput)
+				if (convertedOutput instanceof Message messageResult) {
+					enrichedMessage = MessageBuilder.fromMessage(messageResult)
 						.setHeader(MessageHeaders.CONTENT_TYPE, contentType[0]).build();
 				}
 				else {
@@ -1550,7 +1552,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 			}
 
 			if (StringUtils.hasText(contentType)) {
-				Map<String, Object> headersMap = new HashMap(((Message) output).getHeaders());
+				Map<String, Object> headersMap = new HashMap<>(((Message) output).getHeaders());
 				String[] expectedContentTypes = StringUtils.delimitedListToStringArray(contentType, ",");
 				for (String expectedContentType : expectedContentTypes) {
 					headersMap.put(MessageHeaders.CONTENT_TYPE, expectedContentType);
@@ -1569,8 +1571,8 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 		 */
 		@SuppressWarnings("unchecked")
 		private Object convertMultipleOutputValuesIfNecessary(Object output, String[] contentType) {
-			Collection outputCollection = ObjectUtils.isArray(output) ? CollectionUtils.arrayToList(output) : (Collection) output;
-			Collection convertedOutputCollection = outputCollection instanceof List ? new ArrayList<>() : new TreeSet<>();
+			Collection<?> outputCollection = ObjectUtils.isArray(output) ? CollectionUtils.arrayToList(output) : (Collection<?>) output;
+			Collection<Object> convertedOutputCollection = outputCollection instanceof List ? new ArrayList<>() : new TreeSet<>();
 			Type type = this.isOutputTypeMessage() ? FunctionTypeUtils.getGenericType(this.outputType) : this.outputType;
 			for (Object outToConvert : outputCollection) {
 				Object result = this.convertOutputIfNecessary(outToConvert, type, contentType);
@@ -1641,23 +1643,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 	/**
 	 *
 	 */
-	private static final class OriginalMessageHolder  {
-		private final Object value;
-
-		private final Message<?> originalMessage;
-
-		private OriginalMessageHolder(Object value, Message<?> originalMessage) {
-			this.value = value;
-			this.originalMessage = originalMessage;
-		}
-
-		public Object getValue() {
-			return this.value;
-		}
-
-		public Message<?> getOriginalMessage() {
-			return this.originalMessage;
-		}
+	private record OriginalMessageHolder(Object value, Message<?> originalMessage) {
 	}
 
 	public static class PassThruFunction implements Function<Object, Object> {
@@ -1668,13 +1654,7 @@ public class SimpleFunctionRegistry implements FunctionRegistry {
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private static class ConsumerWrapper implements Consumer<Flux<Object>> {
-
-		private final Consumer targetConsumer;
-
-		ConsumerWrapper(Consumer targetConsumer) {
-			this.targetConsumer = targetConsumer;
-		}
+	private record ConsumerWrapper(Consumer targetConsumer) implements Consumer<Flux<Object>> {
 
 		@Override
 		public void accept(Flux messageFlux) {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfiguration.java
@@ -175,7 +175,7 @@ public class ContextFunctionCatalogAutoConfiguration {
 								BeanFactory beanFactory, @Nullable MessageRoutingCallback routingCallback,
 								@Nullable DefaultMessageRoutingHandler defaultMessageRoutingHandler) {
 		if (defaultMessageRoutingHandler != null) {
-			FunctionRegistration functionRegistration = new FunctionRegistration(defaultMessageRoutingHandler, RoutingFunction.DEFAULT_ROUTE_HANDLER);
+			FunctionRegistration functionRegistration = new FunctionRegistration<>(defaultMessageRoutingHandler, RoutingFunction.DEFAULT_ROUTE_HANDLER);
 			functionRegistration.type(FunctionTypeUtils.consumerType(ResolvableType.forClassWithGenerics(Message.class, Object.class).getType()));
 			((FunctionRegistry) functionCatalog).register(functionRegistration);
 		}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializer.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializer.java
@@ -128,7 +128,7 @@ public class ContextFunctionCatalogInitializer implements ApplicationContextInit
 					.containsBeanDefinition(AnnotationConfigUtils.CONFIGURATION_ANNOTATION_PROCESSOR_BEAN_NAME)) {
 				// Switch off the ConfigurationClassPostProcessor
 				this.context.registerBean(AnnotationConfigUtils.CONFIGURATION_ANNOTATION_PROCESSOR_BEAN_NAME,
-						DummyProcessor.class, () -> new DummyProcessor());
+						DummyProcessor.class, DummyProcessor::new);
 				// But switch on other annotation processing
 				AnnotationConfigUtils.registerAnnotationConfigProcessors(this.context);
 			}
@@ -138,7 +138,7 @@ public class ContextFunctionCatalogInitializer implements ApplicationContextInit
 
 			if (ClassUtils.isPresent("com.google.gson.Gson", null) && "gson".equals(preferredMapper)) {
 				if (this.context.getBeanFactory().getBeanNamesForType(Gson.class, false, false).length == 0) {
-					this.context.registerBean(Gson.class, () -> new Gson());
+					this.context.registerBean(Gson.class, Gson::new);
 				}
 				this.context.registerBean(JsonMapper.class, () -> new ContextFunctionCatalogAutoConfiguration.JsonMapperConfiguration().jsonMapper(this.context));
 			}
@@ -185,7 +185,7 @@ public class ContextFunctionCatalogInitializer implements ApplicationContextInit
 					int cacheSize = this.context.getEnvironment().getProperty("spring.cloud.function.registry.cache-size", int.class, 1000);
 					return new SimpleFunctionRegistry(conversionService, messageConverter, this.context.getBean(JsonMapper.class), null, null, cacheSize);
 				});
-				this.context.registerBean(FunctionProperties.class, () -> new FunctionProperties());
+				this.context.registerBean(FunctionProperties.class, FunctionProperties::new);
 				this.context.registerBean(FunctionRegistrationPostProcessor.class,
 						() -> new FunctionRegistrationPostProcessor(this.context.getAutowireCapableBeanFactory()
 								.getBeanProvider(FunctionRegistration.class)));
@@ -201,7 +201,7 @@ public class ContextFunctionCatalogInitializer implements ApplicationContextInit
 
 					@Override
 					public void run() {
-						runSafely(() -> new DefaultFormattingConversionService());
+						runSafely(DefaultFormattingConversionService::new);
 					}
 
 					public void runSafely(Runnable runnable) {
@@ -232,8 +232,7 @@ public class ContextFunctionCatalogInitializer implements ApplicationContextInit
 
 			@Override
 			public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-				if (bean instanceof FunctionRegistry) {
-					FunctionRegistry catalog = (FunctionRegistry) bean;
+				if (bean instanceof FunctionRegistry catalog) {
 					for (FunctionRegistration<?> registration : this.functions) {
 						Assert.notEmpty(registration.getNames(),
 								"FunctionRegistration must define at least one name. Was empty");

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/FunctionContextUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/FunctionContextUtils.java
@@ -70,8 +70,8 @@ public abstract class FunctionContextUtils {
 		Object source = definition.getSource();
 
 		Type param = null;
-		if (source instanceof MethodMetadata) {
-			param = findBeanType(definition, ((MethodMetadata) source).getDeclaringClassName(), ((MethodMetadata) source).getMethodName());
+		if (source instanceof MethodMetadata methodMetadata) {
+			param = findBeanType(definition, methodMetadata.getDeclaringClassName(), methodMetadata.getMethodName());
 		}
 		else if (source instanceof Resource) {
 			param = registry.getType(actualName);
@@ -89,8 +89,7 @@ public abstract class FunctionContextUtils {
 
 	public static Class<?>[] getParamTypesFromBeanDefinitionFactory(Class<?> factory,
 			AbstractBeanDefinition definition, String methodName) {
-		if (definition instanceof RootBeanDefinition) {
-			RootBeanDefinition root = (RootBeanDefinition) definition;
+		if (definition instanceof RootBeanDefinition root) {
 			for (Method method : getCandidateMethods(factory, root)) {
 				if (method.getName().equals(methodName) && AnnotationUtils.findAnnotation(method, Bean.class) != null) {
 					return method.getParameterTypes();

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/SmartCompositeMessageConverter.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/SmartCompositeMessageConverter.java
@@ -171,8 +171,8 @@ public class SmartCompositeMessageConverter extends CompositeMessageConverter {
 			String[] contentTypes = StringUtils.delimitedListToStringArray((String) value, ",");
 			for (String contentType : contentTypes) {
 				if (!MimeType.valueOf(contentType).isConcrete()) {
-					if (converter instanceof AbstractMessageConverter) {
-						List<MimeType> supportedMimeTypes = ((AbstractMessageConverter) converter).getSupportedMimeTypes();
+					if (converter instanceof AbstractMessageConverter abstractMessageConverter) {
+						List<MimeType> supportedMimeTypes = abstractMessageConverter.getSupportedMimeTypes();
 						for (MimeType supportedMimeType : supportedMimeTypes) {
 							if (supportedMimeType.isCompatibleWith(MimeType.valueOf(contentType))) {
 								MessageHeaderAccessor h = new MessageHeaderAccessor();

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/message/MessageUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/message/MessageUtils.java
@@ -46,13 +46,11 @@ public abstract class MessageUtils {
 	/**
 	 * !!! INTERNAL USE ONLY, MAY CHANGE OR REMOVED WITHOUT NOTICE!!!
 	 */
-	@SuppressWarnings({"rawtypes"})
 	public static class MessageStructureWithCaseInsensitiveHeaderKeys {
 		private final Object payload;
-		private final Map headers;
+		private final Map<String, Object> headers;
 
-		@SuppressWarnings("unchecked")
-		MessageStructureWithCaseInsensitiveHeaderKeys(Message message) {
+		MessageStructureWithCaseInsensitiveHeaderKeys(Message<?> message) {
 			this.payload = message.getPayload();
 			this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 			this.headers.putAll(message.getHeaders());
@@ -61,7 +59,7 @@ public abstract class MessageUtils {
 			return payload;
 		}
 
-		public Map getHeaders() {
+		public Map<String, Object> getHeaders() {
 			return headers;
 		}
 	}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/GsonMapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/GsonMapper.java
@@ -46,14 +46,14 @@ public class GsonMapper extends JsonMapper {
 		if (json instanceof byte[]) {
 			convertedValue = this.gson.fromJson(new String(((byte[]) json), StandardCharsets.UTF_8), type);
 		}
-		else if (json instanceof String) {
-			convertedValue = this.gson.fromJson((String) json, type);
+		else if (json instanceof String s) {
+			convertedValue = this.gson.fromJson(s, type);
 		}
-		else if (json instanceof Reader) {
-			convertedValue = this.gson.fromJson((Reader) json, type);
+		else if (json instanceof Reader reader) {
+			convertedValue = this.gson.fromJson(reader, type);
 		}
-		else if (json instanceof JsonElement) {
-			convertedValue = this.gson.fromJson((JsonElement) json, type);
+		else if (json instanceof JsonElement jsonElement) {
+			convertedValue = this.gson.fromJson(jsonElement, type);
 		}
 		return convertedValue;
 	}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JacksonMapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JacksonMapper.java
@@ -57,14 +57,14 @@ public class JacksonMapper extends JsonMapper {
 		JavaType constructType = TypeFactory.createDefaultInstance().constructType(type);
 
 		try {
-			if (json instanceof String) {
-				convertedValue = this.mapper.readValue((String) json, constructType);
+			if (json instanceof String s) {
+				convertedValue = this.mapper.readValue(s, constructType);
 			}
-			else if (json instanceof byte[]) {
-				convertedValue = this.mapper.readValue((byte[]) json, constructType);
+			else if (json instanceof byte[] bytes) {
+				convertedValue = this.mapper.readValue(bytes, constructType);
 			}
-			else if (json instanceof Reader) {
-				convertedValue = this.mapper.readValue((Reader) json, constructType);
+			else if (json instanceof Reader reader) {
+				convertedValue = this.mapper.readValue(reader, constructType);
 			}
 			else if (json instanceof Map) {
 				convertedValue = this.mapper.convertValue(json, constructType);

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JsonMapper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/json/JsonMapper.java
@@ -51,11 +51,10 @@ public abstract class JsonMapper {
 
 	@SuppressWarnings("unchecked")
 	public <T> T fromJson(Object json, Type type) {
-		if (json instanceof Collection<?>) {
+		if (json instanceof Collection<?> inputs) {
 			if (FunctionTypeUtils.isTypeCollection(type)) {
 				return (T) json;
 			}
-			Collection<?> inputs = (Collection<?>) json;
 			Type itemType = FunctionTypeUtils.getImmediateGenericType(type, 0);
 			Collection<?> results = FunctionTypeUtils.getRawType(type).isAssignableFrom(List.class)
 					? new ArrayList<>()
@@ -115,11 +114,11 @@ public abstract class JsonMapper {
 		if (value instanceof byte[]) {
 			value = new String((byte[]) value, StandardCharsets.UTF_8);
 		}
-		if (value instanceof String) {
+		if (value instanceof String s) {
 			try {
-				mapper.readTree((String) value);
+				mapper.readTree(s);
 				try {
-					Integer.parseInt((String) value);
+					Integer.parseInt(s);
 					return false;
 				}
 				catch (Exception e) {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/utils/JsonMasker.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/utils/JsonMasker.java
@@ -104,16 +104,16 @@ public final class JsonMasker {
 
 	@SuppressWarnings({ "unchecked" })
 	private String iterate(Object json) {
-		if (json instanceof Collection arrayValue) {
+		if (json instanceof Collection<?> arrayValue) {
 			for (Object element : arrayValue) {
-				if (element instanceof Map mapElement) {
+				if (element instanceof Map<?, ?> mapElement) {
 					for (Map.Entry<String, Object> entry : ((Map<String, Object>) mapElement).entrySet()) {
 						this.doMask(entry.getKey(), entry);
 					}
 				}
 			}
 		}
-		else if (json instanceof Map mapElement) {
+		else if (json instanceof Map<?, ?> mapElement) {
 			for (Map.Entry<String, Object> entry : ((Map<String, Object>) mapElement).entrySet()) {
 				this.doMask(entry.getKey(), entry);
 			}

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryMultiInOutTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryMultiInOutTests.java
@@ -331,8 +331,8 @@ public class BeanFactoryAwareFunctionRegistryMultiInOutTests {
 		public Function<Flux<Person>, Tuple3<Flux<Person>, Flux<String>, Flux<Integer>>> multiOutputAsTuplePojoIn() {
 			return flux -> {
 				Flux<Person> pubSubFlux = flux.publish().autoConnect(3);
-				Flux<String> nameFlux = pubSubFlux.map(person -> person.getName());
-				Flux<Integer> idFlux = pubSubFlux.map(person -> person.getId());
+				Flux<String> nameFlux = pubSubFlux.map(Person::getName);
+				Flux<Integer> idFlux = pubSubFlux.map(Person::getId);
 				return Tuples.of(pubSubFlux, nameFlux, idFlux);
 			};
 		}
@@ -340,9 +340,9 @@ public class BeanFactoryAwareFunctionRegistryMultiInOutTests {
 		@Bean
 		public Function<Flux<Message<Person>>, Tuple3<Flux<Person>, Flux<String>, Flux<Integer>>> multiOutputAsTupleMessageIn() {
 			return flux -> {
-				Flux<Person> pubSubFlux = flux.map(message -> message.getPayload()).publish().autoConnect(3);
-				Flux<String> nameFlux = pubSubFlux.map(person -> person.getName());
-				Flux<Integer> idFlux = pubSubFlux.map(person -> person.getId());
+				Flux<Person> pubSubFlux = flux.map(Message::getPayload).publish().autoConnect(3);
+				Flux<String> nameFlux = pubSubFlux.map(Person::getName);
+				Flux<Integer> idFlux = pubSubFlux.map(Person::getId);
 				return Tuples.of(pubSubFlux, nameFlux, idFlux);
 			};
 		}

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/BeanFactoryAwareFunctionRegistryTests.java
@@ -208,17 +208,16 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		assertThat(CompositionReactiveSupplierWithConsumer.RESULTS.get(1)).isEqualTo("BUBBLES");
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testMessageWithArrayAsPayload() throws Exception {
 		FunctionCatalog catalog = this.configureCatalog(MessageWithArrayAsPayload.class);
 		FunctionInvocationWrapper function = catalog.lookup("myFunction");
 
-		List payload = List.of("Ricky", "Julien", "Bubbles");
+		List<String> payload = List.of("Ricky", "Julien", "Bubbles");
 
-		Message result = (Message) function.apply(MessageBuilder.withPayload(payload).build());
+		Message<?> result = (Message<?>) function.apply(MessageBuilder.withPayload(payload).build());
 
-		assertThat(((Collection) result.getPayload())).isNotEmpty();
+		assertThat(((Collection<?>) result.getPayload())).isNotEmpty();
 
 	}
 
@@ -234,7 +233,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	@Test
 	public void testFunctionEligibilityFiltering() {
 		System.setProperty("spring.cloud.function.ineligible-definitions", "asJsonNode");
-		Collection<FunctionInvocationWrapper> registeredFunction = new ArrayList<FunctionInvocationWrapper>();
+		Collection<FunctionInvocationWrapper> registeredFunction = new ArrayList<>();
 		FunctionCatalog catalog = this.configureCatalog(JsonNodeConfiguration.class);
 		for (String beanName : context.getBeanDefinitionNames()) {
 			try {
@@ -262,23 +261,18 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		assertThat(new String(f.apply(m).getPayload())).isEqualTo("[{\"name\":\"bob\"},{\"name\":\"bob\"}]");
 	}
 
-	@SuppressWarnings({ "rawtypes" })
 	@Test
 	public void concurrencyLookupTest() throws Exception {
 		FunctionCatalog catalog = this.configureCatalog();
 		ExecutorService executor = Executors.newCachedThreadPool();
 		for (int i = 0; i < 100; i++) {
-			executor.execute(() -> {
-				catalog.lookup("uppercase", "application/json");
-			});
-			executor.execute(() -> {
-				catalog.lookup("numberword", "application/json");
-			});
+			executor.execute(() -> catalog.lookup("uppercase", "application/json"));
+			executor.execute(() -> catalog.lookup("numberword", "application/json"));
 		}
 		Thread.sleep(1000);
 		Field frField = ReflectionUtils.findField(catalog.getClass(), "functionRegistrations");
 		frField.setAccessible(true);
-		Collection c = (Collection) frField.get(catalog);
+		Collection<?> c = (Collection<?>) frField.get(catalog);
 		assertThat(c.size()).isEqualTo(2);
 	}
 
@@ -368,10 +362,10 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		assertThat(consumerFunction.apply("hello")).isNull();
 
 		Function<Message<byte[]>, Void> consumerFunctionAsMessageA = catalog.lookup("consumerFunction");
-		assertThat(consumerFunctionAsMessageA.apply(new GenericMessage<byte[]>("\"hello\"".getBytes()))).isNull();
+		assertThat(consumerFunctionAsMessageA.apply(new GenericMessage<>("\"hello\"".getBytes()))).isNull();
 
 		Function<Message<byte[]>, Void> consumerFunctionAsMessageB = catalog.lookup("consumerFunction", "application/json");
-		assertThat(consumerFunctionAsMessageB.apply(new GenericMessage<byte[]>("\"hello\"".getBytes()))).isNull();
+		assertThat(consumerFunctionAsMessageB.apply(new GenericMessage<>("\"hello\"".getBytes()))).isNull();
 	}
 
 	@Test
@@ -647,17 +641,16 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		assertThat(result.getPayload()).isEqualTo("\"b2xsZWg=\"".getBytes());
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testMultipleValuesInOutputHandling() throws Exception {
 		FunctionCatalog catalog = this.configureCatalog(CollectionOutConfiguration.class);
 		FunctionInvocationWrapper function = catalog.lookup("parseToList", "application/json");
 		assertThat(function).isNotNull();
 		Object result = function.apply(MessageBuilder.withPayload("1,2,3".getBytes()).setHeader(MessageHeaders.CONTENT_TYPE, "text/plain").build());
-		assertThat(result instanceof Message).isTrue();
-		byte[] payload = ((Message<byte[]>) result).getPayload();
+		assertThat(result instanceof Message<?>).isTrue();
+		byte[] payload = (byte[]) ((Message<?>) result).getPayload();
 		JsonMapper mapper = this.context.getBean(JsonMapper.class);
-		List resultList = mapper.fromJson(payload, List.class);
+		List<?> resultList = mapper.fromJson(payload, List.class);
 		assertThat(resultList.size()).isEqualTo(3);
 		assertThat(resultList.get(0)).isEqualTo("1");
 		assertThat(resultList.get(1)).isEqualTo("2");
@@ -665,7 +658,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		function = catalog.lookup("parseToListOfMessages", "application/json");
 		assertThat(function).isNotNull();
 		result = function.apply(MessageBuilder.withPayload("1,2,3".getBytes()).setHeader(MessageHeaders.CONTENT_TYPE, "text/plain").build());
-		assertThat(result instanceof List).isTrue();
+		assertThat(result instanceof List<?>).isTrue();
 		assertThat(((Message<?>) ((List<?>) result).get(0)).getHeaders()).containsKey("foo");
 		assertThat(((Message<?>) ((List<?>) result).get(1)).getHeaders()).containsKey("foo");
 		assertThat(((Message<?>) ((List<?>) result).get(2)).getHeaders()).containsKey("foo");
@@ -726,7 +719,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	public void testWithComplexHierarchyAndTypeConversion() {
 		FunctionCatalog catalog = this.configureCatalog(ReactiveFunctionImpl.class);
 		Function<Object, Flux> f = catalog.lookup("");
-		assertThat(f.apply(new GenericMessage("23")).blockFirst()).isEqualTo(23);
+		assertThat(f.apply(new GenericMessage<>("23")).blockFirst()).isEqualTo(23);
 		assertThat(f.apply(Flux.just("25")).blockFirst()).isEqualTo(25);
 		assertThat(f.apply(Flux.just(25)).blockFirst()).isEqualTo(25);
 	}
@@ -765,7 +758,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	public void testWrappedWithAroundAdviseConfiguration() {
 		FunctionCatalog catalog = this.configureCatalog(WrappedWithAroundAdviseConfiguration.class);
 		Function f = catalog.lookup("uppercase");
-		Message result = (Message) f.apply(new GenericMessage<String>("hello"));
+		Message result = (Message) f.apply(new GenericMessage<>("hello"));
 		assertThat(result.getHeaders().get("before")).isEqualTo("foo");
 		assertThat(result.getHeaders().get("after")).isEqualTo("bar");
 	}
@@ -813,7 +806,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 
 
-		result = (Flux) f.apply(new GenericMessage<String>("[{\"id\":1, \"name\":\"oleg\"}, {\"id\":2, \"name\":\"seva\"}]"));
+		result = (Flux) f.apply(new GenericMessage<>("[{\"id\":1, \"name\":\"oleg\"}, {\"id\":2, \"name\":\"seva\"}]"));
 		list = (List) result.collectList().block();
 		assertThat(list.size()).isEqualTo(2);
 		assertThat(list.get(0).name).isEqualTo("OLEG");
@@ -865,20 +858,20 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		assertThat(result.block()).isEqualTo("hello");
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testGH_635() throws Exception {
 		FunctionCatalog catalog = this.configureCatalog(SCF_GH_635ConfigurationAsFunction.class);
-		Function lmFunction = catalog.lookup("emptyMessageList", "application/json");
+		FunctionInvocationWrapper lmFunction = catalog.lookup("emptyMessageList", "application/json");
 		List<Message<?>> emptyListOfMessages = (List<Message<?>>) lmFunction.apply(MessageBuilder.withPayload("hello").build());
 		assertThat(emptyListOfMessages).isEmpty();
 		emptyListOfMessages = (List<Message<?>>) lmFunction.apply("hello");
 		assertThat(emptyListOfMessages).isEmpty();
 
 		JsonMapper mapper = this.context.getBean(JsonMapper.class);
-		Function lsFunction = catalog.lookup("emptyStringList", "application/json");
+		FunctionInvocationWrapper lsFunction = catalog.lookup("emptyStringList", "application/json");
 		Message<byte[]> emptyListOfString = (Message<byte[]>) lsFunction.apply(MessageBuilder.withPayload("hello").build());
-		List resultList = mapper.fromJson(emptyListOfString.getPayload(), List.class);
+		List<?> resultList = mapper.fromJson(emptyListOfString.getPayload(), List.class);
 		assertThat(resultList).isEmpty();
 		emptyListOfString = (Message<byte[]>) lsFunction.apply("hello");
 		resultList = mapper.fromJson(emptyListOfString.getPayload(), List.class);
@@ -977,7 +970,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 		@Bean
 		public Function<Message<String>, String> echo() {
-			return v -> v.getPayload();
+			return Message::getPayload;
 		}
 
 		@Bean
@@ -996,16 +989,12 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	public static class JsonNodeConfiguration {
 		@Bean
 		public Function<Message<JsonNode>, String> messageAsJsonNode() {
-			return v -> {
-				return v.getPayload().toString();
-			};
+			return v -> v.getPayload().toString();
 		}
 
 		@Bean
 		public Function<JsonNode, String> asJsonNode() {
-			return v -> {
-				return v.toString();
-			};
+			return Object::toString;
 		}
 	}
 
@@ -1023,7 +1012,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 	public static class ReactiveFunctionImpl implements ReactiveFunction<String, Integer> {
 		@Override
 		public Flux<Integer> apply(Flux<String> inFlux) {
-			return inFlux.map(v -> Integer.parseInt(v));
+			return inFlux.map(Integer::parseInt);
 		}
 	}
 
@@ -1221,9 +1210,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 		@Bean
 		public Function<Person, Person> uppercasePerson() {
-			return person -> {
-				return new Person(person.getName().toUpperCase(Locale.ROOT), person.getId());
-			};
+			return person -> new Person(person.getName().toUpperCase(Locale.ROOT), person.getId());
 		}
 
 		@Bean
@@ -1232,10 +1219,8 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		}
 
 		@Bean
-		public BiFunction<String, Map, String> biFuncUpperCase() {
-			return (p, h) -> {
-				return p.toUpperCase(Locale.ROOT);
-			};
+		public BiFunction<String, Map<?, ?>, String> biFuncUpperCase() {
+			return (p, h) -> p.toUpperCase(Locale.ROOT);
 		}
 
 		@Bean
@@ -1295,9 +1280,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 		@Bean
 		public Function<Flux<String>, Flux<String>> reverseFlux() {
-			return flux -> flux.map(value -> {
-				return new StringBuilder(value).reverse().toString();
-			});
+			return flux -> flux.map(value -> new StringBuilder(value).reverse().toString());
 		}
 
 
@@ -1325,8 +1308,8 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		public Function<Flux<Person>, Tuple3<Flux<Person>, Flux<String>, Flux<Integer>>> multiOutputAsTuple() {
 			return flux -> {
 				Flux<Person> pubSubFlux = flux.publish().autoConnect(3);
-				Flux<String> nameFlux = pubSubFlux.map(person -> person.getName());
-				Flux<Integer> idFlux = pubSubFlux.map(person -> person.getId());
+				Flux<String> nameFlux = pubSubFlux.map(Person::getName);
+				Flux<Integer> idFlux = pubSubFlux.map(Person::getId);
 				return Tuples.of(pubSubFlux, nameFlux, idFlux);
 			};
 		}
@@ -1395,7 +1378,7 @@ public class BeanFactoryAwareFunctionRegistryTests {
 		@Bean
 		// Perhaps it should not be allowed. Recommend Function<Flux, Mono<Void>>
 		public Consumer<Flux<Person>> reactivePojoConsumer() {
-			return flux -> flux.subscribe(v -> consumerInputRef.set(v));
+			return flux -> flux.subscribe(consumerInputRef::set);
 		}
 
 		@Bean
@@ -1646,9 +1629,9 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 	@EnableAutoConfiguration
 	@Configuration // s-c-f-1141
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static class CompositionReactiveSupplierWithConsumer {
-		private static final List RESULTS = new ArrayList<>();
+		private static final List<Object> RESULTS = new ArrayList<>();
 
 		@Bean
 		public Function<Flux<String>, Flux<String>> functionPrimitive() {
@@ -1662,18 +1645,14 @@ public class BeanFactoryAwareFunctionRegistryTests {
 
 		@Bean
 		public Supplier<Flux<Message<Integer>>> supplyMessage() {
-			return () -> {
-				return Flux.fromArray(
+			return () -> Flux.fromArray(
 						new Message[] { MessageBuilder.withPayload(1).build(), MessageBuilder.withPayload(2).build() });
-			};
 		}
 
 		@Bean
 		public Supplier<Flux<Integer>> supplyPrimitive() {
-			return () -> {
-				return Flux.fromArray(
+			return () -> Flux.fromArray(
 						new Integer[] { 1, 2});
-			};
 		}
 
 		@Bean

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtilsTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/FunctionTypeUtilsTests.java
@@ -120,7 +120,7 @@ public class FunctionTypeUtilsTests {
 	public void testWithComplexGenericsHierarchy() throws Exception {
 		Type functionType = FunctionTypeUtils.discoverFunctionTypeFromFunctionFactoryMethod(FunctionTypeUtilsTests.class, "methodWithGenerics");
 		Type inputType = FunctionTypeUtils.getInputType(functionType);
-		Class typeClass = FunctionTypeUtils.getRawType(inputType);
+		Class<?> typeClass = FunctionTypeUtils.getRawType(inputType);
 		assertThat(typeClass).isAssignableFrom(Message.class);
 		ParameterizedType parameterizedInputType = (ParameterizedType) inputType;
 		Type[] typeArguments = parameterizedInputType.getActualTypeArguments();
@@ -264,7 +264,7 @@ public class FunctionTypeUtilsTests {
 	}
 
 	public static GenericBatchMessageListConsumer<SomeDomainObject> methodWithGenerics() {
-		return new GenericBatchMessageListConsumer<SomeDomainObject>();
+		return new GenericBatchMessageListConsumer<>();
 	}
 
 	//============
@@ -299,7 +299,7 @@ public class FunctionTypeUtilsTests {
 
 		@Override
 		public Flux<Integer> apply(Flux<String> inFlux) {
-			return inFlux.map(v -> Integer.parseInt(v));
+			return inFlux.map(Integer::parseInt);
 		}
 	}
 

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/catalog/SimpleFunctionRegistryTests.java
@@ -135,7 +135,6 @@ public class SimpleFunctionRegistryTests {
 		assertThat(lookedUpFunction.apply(inputMessage)).isEqualTo(stringValue);
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Test
 	public void concurrencyRegistrationTest() throws Exception {
 		Echo function = new Echo();
@@ -145,14 +144,12 @@ public class SimpleFunctionRegistryTests {
 				new JacksonMapper(new ObjectMapper()));
 		ExecutorService executor = Executors.newCachedThreadPool();
 		for (int i = 0; i < 1000; i++) {
-			executor.execute(() -> {
-				catalog.register(registration);
-			});
+			executor.execute(() -> catalog.register(registration));
 		}
 		Thread.sleep(1000);
 		Field frField = ReflectionUtils.findField(catalog.getClass(), "functionRegistrations");
 		frField.setAccessible(true);
-		Collection c = (Collection) frField.get(catalog);
+		Collection<?> c = (Collection<?>) frField.get(catalog);
 		assertThat(c.size()).isEqualTo(1);
 	}
 
@@ -615,13 +612,13 @@ public class SimpleFunctionRegistryTests {
 			new JacksonMapper(new ObjectMapper()));
 
 		Object reactiveFunc = reactiveFluxSupplier();
-		FunctionRegistration functionRegistration = new FunctionRegistration(reactiveFunc, "reactiveFluxSupplier")
+		FunctionRegistration<?> functionRegistration = new FunctionRegistration<>(reactiveFunc, "reactiveFluxSupplier")
 			.type(ResolvableType.forClassWithGenerics(
 				Supplier.class, ResolvableType.forClassWithGenerics(Flux.class, String.class)).getType());
 		catalog.register(functionRegistration);
 
 		reactiveFunc = reactiveFluxConsumer();
-		functionRegistration = new FunctionRegistration(reactiveFunc, "reactiveFluxConsumer")
+		functionRegistration = new FunctionRegistration<>(reactiveFunc, "reactiveFluxConsumer")
 			.type(ResolvableType.forClassWithGenerics(
 				Consumer.class, ResolvableType.forClassWithGenerics(Flux.class, String.class)).getType());
 		catalog.register(functionRegistration);
@@ -659,7 +656,7 @@ public class SimpleFunctionRegistryTests {
 
 
 	public Function<Object, Integer> hash() {
-		return v -> v.hashCode();
+		return Object::hashCode;
 	}
 
 	public Supplier<Integer> supplier() {
@@ -671,9 +668,7 @@ public class SimpleFunctionRegistryTests {
 	}
 
 	public Consumer<Flux<Integer>> reactiveConsumer() {
-		return flux -> flux.subscribe(v -> {
-			System.out.println(v);
-		});
+		return flux -> flux.subscribe(System.out::println);
 	}
 
 	private final AtomicInteger consumerDowncounter = new AtomicInteger(10);
@@ -734,7 +729,7 @@ public class SimpleFunctionRegistryTests {
 
 		@Bean
 		public Function<Person, String> func() {
-			return person -> person.getName();
+			return Person::getName;
 		}
 	}
 

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogAutoConfigurationTests.java
@@ -498,9 +498,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 
 		@Bean
 		public Consumer<String> consumer() {
-			return value -> {
-				this.list.add(value);
-			};
+			return this.list::add;
 		}
 
 	}
@@ -628,7 +626,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 
 		@Bean
 		public Function<Map<String, String>, Map<String, String>> function() {
-			return m -> m.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(),
+			return m -> m.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
 					e -> e.getValue().toString().toUpperCase(Locale.ROOT)));
 		}
 
@@ -723,7 +721,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 		@Bean
 		public Function<Flux<Map<String, String>>, Flux<Map<String, String>>> function() {
 			return flux -> flux.map(m -> m.entrySet().stream().collect(Collectors
-					.toMap(e -> e.getKey(), e -> e.getValue().toString().toUpperCase(Locale.ROOT))));
+					.toMap(Map.Entry::getKey, e -> e.getValue().toString().toUpperCase(Locale.ROOT))));
 		}
 
 	}
@@ -815,7 +813,7 @@ public class ContextFunctionCatalogAutoConfigurationTests {
 
 		@Bean
 		public FunctionRegistration<Function<String, String>> registration() {
-			return new FunctionRegistration<Function<String, String>>(function(),
+			return new FunctionRegistration<>(function(),
 					"other");
 		}
 

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializerTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/context/config/ContextFunctionCatalogInitializerTests.java
@@ -276,7 +276,7 @@ public class ContextFunctionCatalogInitializerTests {
 
 		@Bean
 		public Consumer<String> consumer() {
-			return value -> this.list.add(value);
+			return this.list::add;
 		}
 	}
 
@@ -351,7 +351,7 @@ public class ContextFunctionCatalogInitializerTests {
 
 		@Override
 		public void initialize(GenericApplicationContext context) {
-			context.registerBean(String.class, () -> value());
+			context.registerBean(String.class, this::value);
 			context.registerBean("foos", FunctionRegistration.class,
 					() -> new FunctionRegistration<>(foos(context.getBean(String.class)))
 							.type(FunctionTypeUtils.functionType(String.class, Foo.class)));

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/scan/ScannedFunction.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/scan/ScannedFunction.java
@@ -33,7 +33,7 @@ public class ScannedFunction
 
 	@Override
 	public Map<String, String> apply(Map<String, String> m) {
-		return m.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(),
+		return m.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
 				e -> e.getValue().toString().toUpperCase(Locale.ROOT)));
 	}
 

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/test/GenericFunction.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/test/GenericFunction.java
@@ -33,7 +33,7 @@ public class GenericFunction {
 
 	@Bean
 	public Function<Map<String, String>, Map<String, String>> function() {
-		return m -> m.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(),
+		return m -> m.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
 				e -> e.getValue().toString().toUpperCase(Locale.ROOT)));
 	}
 

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/userissues/UserIssuesTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/userissues/UserIssuesTests.java
@@ -65,7 +65,7 @@ public class UserIssuesTests {
 		FunctionCatalog catalog = this.configureCatalog(Issue602Configuration.class);
 		Function<Message<String>, Integer> function = catalog.lookup("consumer");
 		int result = function.apply(
-				new GenericMessage<String>("[{\"name\":\"julien\"},{\"name\":\"ricky\"},{\"name\":\"bubbles\"}]"));
+				new GenericMessage<>("[{\"name\":\"julien\"},{\"name\":\"ricky\"},{\"name\":\"bubbles\"}]"));
 		assertThat(result).isEqualTo(3);
 	}
 
@@ -76,13 +76,13 @@ public class UserIssuesTests {
 
 
 		List<Object> list = Arrays.asList(new Product[] {new Product("foo"), new Product("bar")});
-		Event event = new Event(list);
-		EventHolder eventHolder = new EventHolder(event);
+		Event event = new Event<>(list);
+		EventHolder eventHolder = new EventHolder<>(event);
 		ObjectMapper mapper = new ObjectMapper();
 		String message = mapper.writeValueAsString(eventHolder);
 		Function function = catalog.lookup("somethingYouShouldNeverDo");
 		boolean result = (boolean) function.apply(
-				new GenericMessage<String>(message));
+				new GenericMessage<>(message));
 		assertThat(result).isTrue();
 	}
 
@@ -103,7 +103,7 @@ public class UserIssuesTests {
 		p = new Product();
 		p.setName("bubbles");
 		products.add(p);
-		int result = function.apply(new GenericMessage<List<Product>>(products));
+		int result = function.apply(new GenericMessage<>(products));
 		assertThat(result).isEqualTo(3);
 
 	}
@@ -116,7 +116,7 @@ public class UserIssuesTests {
 		products.add("{\"name\":\"julien\"}");
 		products.add("{\"name\":\"ricky\"}");
 		products.add("{\"name\":\"bubbles\"}");
-		int result = function.apply(new GenericMessage<List<String>>(products));
+		int result = function.apply(new GenericMessage<>(products));
 		assertThat(result).isEqualTo(3);
 
 	}
@@ -217,7 +217,7 @@ public class UserIssuesTests {
 
 		@Override
 		public Flux<Integer> apply(Flux<String> s) {
-			return s.map(v -> v.length());
+			return s.map(String::length);
 		}
 	}
 

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/utils/JsonMaskerTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/utils/JsonMaskerTests.java
@@ -250,34 +250,33 @@ public class JsonMaskerTests {
 		jsonMaskerField.set(masker, null);
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private void iterate(Object json, List keysToMask) {
-		if (json instanceof Collection arrayValue) {
+	@SuppressWarnings("unchecked")
+	private void iterate(Object json, List<?> keysToMask) {
+		if (json instanceof Collection<?> arrayValue) {
 			for (Object element : arrayValue) {
-				if (element instanceof Map mapElement) {
+				if (element instanceof Map<?, ?> mapElement) {
 					for (Map.Entry<String, Object> entry : ((Map<String, Object>) mapElement).entrySet()) {
 						this.doMask(entry.getKey(), entry, keysToMask);
 					}
 				}
 			}
 		}
-		else if (json instanceof Map mapElement) {
+		else if (json instanceof Map<?, ?> mapElement) {
 			for (Map.Entry<String, Object> entry : ((Map<String, Object>) mapElement).entrySet()) {
 				this.doMask(entry.getKey(), entry, keysToMask);
 			}
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void doMask(String key, Map.Entry<String, Object> entry, List keysToMask) {
+	private void doMask(String key, Map.Entry<String, Object> entry, List<?> keysToMask) {
 		if (keysToMask.contains(key)) {
 			System.out.println("Masked: " + entry.getKey());
 			maskedKeys.add(key);
 		}
-		else if (entry.getValue() instanceof Map) {
+		else if (entry.getValue() instanceof Map<?, ?>) {
 			this.iterate(entry.getValue(), keysToMask);
 		}
-		else if (entry.getValue() instanceof Collection) {
+		else if (entry.getValue() instanceof Collection<?>) {
 			this.iterate(entry.getValue(), keysToMask);
 		}
 	}

--- a/spring-cloud-function-samples/function-sample-aws-custom-bean/src/main/java/com/example/LambdaApplication.java
+++ b/spring-cloud-function-samples/function-sample-aws-custom-bean/src/main/java/com/example/LambdaApplication.java
@@ -22,9 +22,7 @@ public class LambdaApplication {
 
 	@Bean
 	public Consumer<String> consume() {
-		return value -> {
-			logger.info("Consuming: " + value);
-		};
+		return value -> logger.info("Consuming: " + value);
 	}
 
 	@Bean

--- a/spring-cloud-function-samples/function-sample-azure-eventgrid-trigger/src/main/java/com/example/azure/eventgrid/EventGridHandler.java
+++ b/spring-cloud-function-samples/function-sample-azure-eventgrid-trigger/src/main/java/com/example/azure/eventgrid/EventGridHandler.java
@@ -179,7 +179,7 @@ public class EventGridHandler {
 
 		// Parse Event Grid format (array of events)
 		List<Map<String, Object>> eventGridEvents = objectMapper.readValue(
-			requestBody, new TypeReference<List<Map<String, Object>>>() {});
+			requestBody, new TypeReference<>() { });
 
 		StringBuilder results = new StringBuilder();
 

--- a/spring-cloud-function-samples/function-sample/src/main/java/com/example/Client.java
+++ b/spring-cloud-function-samples/function-sample/src/main/java/com/example/Client.java
@@ -33,9 +33,7 @@ public class Client {
 			    .header("accept", "text/event-stream")
 			    .retrieve();
 
-		responseSpec.bodyToFlux(String.class).subscribe(v -> {
-			System.out.println(v);
-		});
+		responseSpec.bodyToFlux(String.class).subscribe(System.out::println);
 
 		System.in.read();
 

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FunctionController.java
@@ -196,8 +196,7 @@ public class FunctionController {
 		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
 		for (String key : body.keySet()) {
 			for (Part part : body.get(key)) {
-				if (part instanceof FormFieldPart) {
-					FormFieldPart form = (FormFieldPart) part;
+				if (part instanceof FormFieldPart form) {
 					map.add(key, form.value());
 				}
 			}

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/ErrorHandlerRegistrar.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/ErrorHandlerRegistrar.java
@@ -31,10 +31,10 @@ public final class ErrorHandlerRegistrar {
 	}
 
 	protected static DefaultErrorWebExceptionHandler errorHandler(GenericApplicationContext context) {
-		context.registerBean(ErrorAttributes.class, () -> new DefaultErrorAttributes());
-		context.registerBean(ErrorProperties.class, () -> new ErrorProperties());
+		context.registerBean(ErrorAttributes.class, DefaultErrorAttributes::new);
+		context.registerBean(ErrorProperties.class, ErrorProperties::new);
 
-		context.registerBean(Resources.class, () -> new Resources());
+		context.registerBean(Resources.class, Resources::new);
 		DefaultErrorWebExceptionHandler handler = new DefaultErrorWebExceptionHandler(
 				context.getBeansOfType(ErrorAttributes.class).values().iterator().next(),
 				context.getBean(Resources.class), context.getBean(ErrorProperties.class), context);

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializer.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializer.java
@@ -106,7 +106,7 @@ public class FunctionEndpointInitializer implements ApplicationContextInitialize
 	}
 
 	private void registerEndpoint(GenericApplicationContext context) {
-		context.registerBean(FunctionHttpProperties.class, () -> new FunctionHttpProperties());
+		context.registerBean(FunctionHttpProperties.class, FunctionHttpProperties::new);
 		context.registerBean(FunctionEndpointFactory.class,
 				() -> new FunctionEndpointFactory(context.getBean(FunctionProperties.class), context.getBean(FunctionCatalog.class),
 						context.getEnvironment(), context.getBean(FunctionHttpProperties.class)));
@@ -150,7 +150,7 @@ public class FunctionEndpointInitializer implements ApplicationContextInitialize
 				logger.info("No web server classes found so no server to start");
 				return;
 			}
-			Integer port = Integer.valueOf(context.getEnvironment().resolvePlaceholders("${server.port:${PORT:8080}}"));
+			int port = Integer.parseInt(context.getEnvironment().resolvePlaceholders("${server.port:${PORT:8080}}"));
 			String address = context.getEnvironment().resolvePlaceholders("${server.address:0.0.0.0}");
 			if (port >= 0) {
 				HttpHandler handler = context.getBeansOfType(HttpHandler.class).values().iterator().next();
@@ -166,8 +166,8 @@ public class FunctionEndpointInitializer implements ApplicationContextInitialize
 
 		private void callback(DisposableServer server, ApplicationContext context) {
 			logger.info("HTTP server started on port: " + server.port());
-			if (context instanceof ConfigurableApplicationContext) {
-				((ConfigurableApplicationContext) context).getEnvironment().getPropertySources().addFirst(
+			if (context instanceof ConfigurableApplicationContext configurableContext) {
+				configurableContext.getEnvironment().getPropertySources().addFirst(
 					new MapPropertySource("functionalServerProps", Collections.singletonMap("local.server.port", server.port())));
 			}
 			try {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/mvc/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/mvc/FunctionController.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.function.web.mvc;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,7 +81,7 @@ public class FunctionController {
 				MultiValueMap<String, MultipartFile> multiFileMap = ((StandardMultipartHttpServletRequest) ((ServletWebRequest) request)
 															.getRequest()).getMultiFileMap();
 				if (!CollectionUtils.isEmpty(multiFileMap)) {
-					List<Message<MultipartFile>> files = multiFileMap.values().stream().flatMap(v -> v.stream())
+					List<Message<MultipartFile>> files = multiFileMap.values().stream().flatMap(Collection::stream)
 							.map(file -> MessageBuilder.withPayload(file).copyHeaders(wrapper.getHeaders().asMultiValueMap()).build())
 							.collect(Collectors.toList());
 					FunctionInvocationWrapper function = wrapper.getFunction();
@@ -88,9 +89,7 @@ public class FunctionController {
 					Publisher<?> result = (Publisher<?>) function.apply(Flux.fromIterable(files));
 					BodyBuilder builder = ResponseEntity.ok();
 					if (result instanceof Flux) {
-						result = Flux.from(result).map(message -> {
-							return message instanceof Message ? ((Message<?>) message).getPayload() : message;
-						}).collectList();
+						result = Flux.from(result).map(message -> message instanceof Message ? ((Message<?>) message).getPayload() : message).collectList();
 					}
 					return Mono.from(result).flatMap(body -> Mono.just(builder.body(body)));
 				}

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/FunctionExporterInitializer.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/FunctionExporterInitializer.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.function.web.source;
 
-import java.util.function.Supplier;
-
 import org.springframework.boot.web.context.reactive.ConfigurableReactiveWebEnvironment;
 import org.springframework.boot.web.context.reactive.ReactiveWebApplicationContext;
 import org.springframework.cloud.function.context.FunctionCatalog;
@@ -30,7 +28,6 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.ConfigurableWebEnvironment;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClient.Builder;
 
 /**
  * @author Dave Syer
@@ -54,12 +51,7 @@ class FunctionExporterInitializer implements ApplicationContextInitializer<Gener
 		if (ClassUtils.isPresent("org.springframework.web.reactive.function.client.WebClient",
 				getClass().getClassLoader())) {
 			if (context.getBeanFactory().getBeanNamesForType(WebClient.Builder.class, false, false).length == 0) {
-				context.registerBean(WebClient.Builder.class, new Supplier<WebClient.Builder>() {
-					@Override
-					public Builder get() {
-						return WebClient.builder();
-					}
-				});
+				context.registerBean(WebClient.Builder.class, WebClient::builder);
 			}
 		}
 	}
@@ -82,7 +74,7 @@ class FunctionExporterInitializer implements ApplicationContextInitializer<Gener
 	}
 
 	private void registerExport(GenericApplicationContext context) {
-		context.registerBean(ExporterProperties.class, () -> new ExporterProperties());
+		context.registerBean(ExporterProperties.class, ExporterProperties::new);
 		context.registerBean(FunctionExporterAutoConfiguration.class,
 				() -> new FunctionExporterAutoConfiguration(context.getBean(ExporterProperties.class), context.getBean(FunctionHttpProperties.class)));
 		if (context.getBeanFactory().getBeanNamesForType(DestinationResolver.class, false, false).length == 0) {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SimpleRequestBuilder.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SimpleRequestBuilder.java
@@ -52,8 +52,7 @@ class SimpleRequestBuilder implements RequestBuilder {
 	@Override
 	public HttpHeaders headers(String destination, Object value) {
 		MessageHeaders incoming = new MessageHeaders(Collections.emptyMap());
-		if (value instanceof Message) {
-			Message<?> message = (Message<?>) value;
+		if (value instanceof Message<?> message) {
 			incoming = message.getHeaders();
 		}
 		HttpHeaders result = HeaderUtils.fromMessage(incoming, this.httpProperties.getIgnoredHeaders());

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SupplierExporter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/source/SupplierExporter.java
@@ -125,9 +125,7 @@ public class SupplierExporter implements SmartLifecycle {
 //						return retry;
 //					}
 //					)
-					.doOnComplete(() -> {
-						stop();
-					})
+					.doOnComplete(this::stop)
 					.subscribe();
 
 			this.ok = true;
@@ -168,7 +166,7 @@ public class SupplierExporter implements SmartLifecycle {
 	}
 
 	private Flux<ClientResponse> forward(Supplier<Publisher<Object>> supplier, String name) {
-		Flux o = (Flux) supplier.get();
+		Flux<?> o = (Flux<?>) supplier.get();
 //		o.subscribe(v -> {
 //			System.out.println(v);
 //		});
@@ -183,8 +181,7 @@ public class SupplierExporter implements SmartLifecycle {
 
 	private Mono<ClientResponse> post(URI uri, String destination, Object value) {
 		Object body = value;
-		if (value instanceof Message) {
-			Message<?> message = (Message<?>) value;
+		if (value instanceof Message<?> message) {
 			body = message.getPayload();
 		}
 		if (this.debug) {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/FunctionWebRequestProcessingHelper.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/FunctionWebRequestProcessingHelper.java
@@ -142,16 +142,14 @@ public final class FunctionWebRequestProcessingHelper {
 		BodyBuilder responseOkBuilder = ResponseEntity.ok().headers(HeaderUtils.sanitize(headers, ignoredHeaders, requestOnlyHeaders));
 
 		Publisher pResult;
-		if (result instanceof Publisher) {
-			pResult = (Publisher) result;
+		if (result instanceof Publisher publisher) {
+			pResult = publisher;
 			if (eventStream) {
 				return Flux.from(pResult);
 			}
 
-			if (pResult instanceof Flux) {
-				pResult = ((Flux) pResult).onErrorContinue((e, v) -> {
-					logger.error("Failed to process value: " + v, (Throwable) e);
-				}).collectList();
+			if (pResult instanceof Flux flux) {
+				pResult = flux.onErrorContinue((e, v) -> logger.error("Failed to process value: " + v, (Throwable) e)).collectList();
 			}
 			pResult = Mono.from(pResult);
 		}
@@ -160,10 +158,10 @@ public final class FunctionWebRequestProcessingHelper {
 		}
 
 		return Mono.from(pResult).map(v -> {
-			if (v instanceof Iterable i) {
-				List aggregatedResult = (List) StreamSupport.stream(i.spliterator(), false).map(m -> {
-					return m instanceof Message ? processMessage(responseOkBuilder, (Message<?>) m, ignoredHeaders) : m;
-				}).collect(Collectors.toList());
+			if (v instanceof Iterable<?> i) {
+				List<?> aggregatedResult = StreamSupport.stream(i.spliterator(), false)
+						.map(m -> m instanceof Message ? processMessage(responseOkBuilder, (Message<?>) m, ignoredHeaders) : m)
+						.collect(Collectors.toList());
 				return responseOkBuilder.header("content-type", "application/json").body(aggregatedResult);
 			}
 			else if (v instanceof Message) {
@@ -228,16 +226,16 @@ public final class FunctionWebRequestProcessingHelper {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private static Object postProcessResult(Object result, boolean isMessage) {
-		if (result instanceof Flux) {
-			result = ((Flux) result).map(v -> postProcessResult(v, isMessage));
+		if (result instanceof Flux flux) {
+			result = flux.map(v -> postProcessResult(v, isMessage));
 		}
-		else if (result instanceof Mono) {
-			result = ((Mono) result).map(v -> postProcessResult(v, isMessage));
+		else if (result instanceof Mono mono) {
+			result = mono.map(v -> postProcessResult(v, isMessage));
 		}
 		else if (result instanceof Message messageResult) {
 			if (messageResult.getPayload() instanceof byte[]) {
 				//String str = new String((byte[]) messageResult.getPayload());
-				result = MessageBuilder.withPayload(messageResult.getPayload()).copyHeaders(((Message) result).getHeaders()).build();
+				result = MessageBuilder.withPayload(messageResult.getPayload()).copyHeaders(messageResult.getHeaders()).build();
 			}
 		}
 		else if (result instanceof byte[]) {

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/flux/FluxRestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/flux/FluxRestApplicationTests.java
@@ -361,7 +361,7 @@ public class FluxRestApplicationTests {
 		@ResponseStatus(HttpStatus.ACCEPTED)
 		public Flux<?> updates(@RequestBody List<String> list) {
 			Flux<String> flux = Flux.fromIterable(list).cache();
-			flux.subscribe(value -> this.list.add(value));
+			flux.subscribe(this.list::add);
 			return flux;
 		}
 
@@ -390,9 +390,7 @@ public class FluxRestApplicationTests {
 
 		@GetMapping("/timeout")
 		public Flux<?> timeout() {
-			return Flux.defer(() -> Flux.<String>create(emitter -> {
-				emitter.next("foo");
-			}).timeout(Duration.ofMillis(100L), Flux.empty()));
+			return Flux.defer(() -> Flux.<String>create(emitter -> emitter.next("foo")).timeout(Duration.ofMillis(100L), Flux.empty()));
 		}
 
 		@GetMapping("/sentences")

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/mvc/MvcRestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/mvc/MvcRestApplicationTests.java
@@ -340,7 +340,7 @@ public class MvcRestApplicationTests {
 		@ResponseStatus(HttpStatus.ACCEPTED)
 		public Flux<?> updates(@RequestBody List<String> list) {
 			Flux<String> flux = Flux.fromIterable(list).cache();
-			flux.subscribe(value -> this.list.add(value));
+			flux.subscribe(this.list::add);
 			return flux;
 		}
 
@@ -369,9 +369,7 @@ public class MvcRestApplicationTests {
 
 		@GetMapping("/timeout")
 		public Flux<?> timeout() {
-			return Flux.defer(() -> Flux.<String>create(emitter -> {
-				emitter.next("foo");
-			}).timeout(Duration.ofMillis(100L), Flux.empty()));
+			return Flux.defer(() -> Flux.<String>create(emitter -> emitter.next("foo")).timeout(Duration.ofMillis(100L), Flux.empty()));
 		}
 
 		@GetMapping("/sentences")

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HeadersToMessageTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HeadersToMessageTests.java
@@ -55,6 +55,7 @@ public class HeadersToMessageTests {
 	@Autowired
 	private TestRestTemplate rest;
 
+	@SuppressWarnings("PMD.AvoidRawTypesForCollections")
 	@Test
 	public void testBodyAndCustomHeaderFromMessagePropagation() throws Exception {
 		// test POJO paylod

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpGetIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpGetIntegrationTests.java
@@ -342,9 +342,7 @@ public class HttpGetIntegrationTests {
 
 		@Bean
 		public Supplier<Flux<String>> timeout() {
-			return () -> Flux.defer(() -> Flux.<String>create(emitter -> {
-				emitter.next("foo");
-			}).timeout(Duration.ofMillis(100L), Flux.empty()));
+			return () -> Flux.defer(() -> Flux.<String>create(emitter -> emitter.next("foo")).timeout(Duration.ofMillis(100L), Flux.empty()));
 		}
 
 		@Bean

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpPostIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/flux/HttpPostIntegrationTests.java
@@ -398,7 +398,7 @@ public class HttpPostIntegrationTests {
 	//@Test
 	@DirtiesContext
 	public void testReactiveFunctionComposdWithImperativeConsumer() throws Exception {
-		RequestEntity entity = RequestEntity.post(new URI("/functionReactive,consumerImperative")).build();
+		RequestEntity<?> entity = RequestEntity.post(new URI("/functionReactive,consumerImperative")).build();
 		this.rest.exchange(entity, String.class);
 		assertThat(ApplicationConfiguration.functionReactiveInvocations).isEqualTo(1);
 	}
@@ -428,9 +428,7 @@ public class HttpPostIntegrationTests {
 
 		@Bean
 		public Consumer<String> consumerImperative() {
-			return value -> {
-				System.out.println(value);
-			};
+			return System.out::println;
 		}
 
 		@Bean({ "uppercase", "transform", "post/more" })
@@ -498,16 +496,12 @@ public class HttpPostIntegrationTests {
 		@Bean
 		@Qualifier("foos")
 		public Function<String, Foo> qualifier() {
-			return value -> {
-				return new Foo("[" + value.trim().toUpperCase(Locale.ROOT) + "]");
-			};
+			return value -> new Foo("[" + value.trim().toUpperCase(Locale.ROOT) + "]");
 		}
 
 		@Bean
 		public Consumer<Flux<String>> updates() {
-			return flux -> flux.subscribe(value -> {
-					this.list.add(value);
-				});
+			return flux -> flux.subscribe(this.list::add);
 		}
 
 		@Bean
@@ -517,16 +511,12 @@ public class HttpPostIntegrationTests {
 
 		@Bean
 		public Consumer<Foo> addFoos() {
-			return value -> {
-				this.list.add(value.getValue());
-			};
+			return value -> this.list.add(value.getValue());
 		}
 
 		@Bean
 		public Consumer<String> bareUpdates() {
-			return value -> {
-				this.list.add(value);
-			};
+			return this.list::add;
 		}
 
 		@Bean("not/a")
@@ -549,7 +539,7 @@ public class HttpPostIntegrationTests {
 
 		@Bean
 		public Function<Flux<List<String>>, Flux<String>> fluxCollectionEcho() {
-			return flux -> flux.flatMap(v -> Flux.fromIterable(v));
+			return flux -> flux.flatMap(Flux::fromIterable);
 		}
 
 	}

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/function/FunctionEndpointInitializerTests.java
@@ -70,7 +70,7 @@ public class FunctionEndpointInitializerTests {
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("Accept", "application/json");
-		HttpEntity entity = new HttpEntity(headers);
+		HttpEntity entity = new HttpEntity<>(headers);
 
 		String urlTemplate = UriComponentsBuilder.fromUriString("http://localhost:" + port + "/nullPayload")
 				.queryParam("fname", "Jim").queryParam("lname", "Lahey").encode().toUriString();
@@ -162,7 +162,7 @@ public class FunctionEndpointInitializerTests {
 			implements ApplicationContextInitializer<GenericApplicationContext> {
 
 		public Consumer<String> consume() {
-			return v -> System.out.println(v);
+			return System.out::println;
 		}
 
 		@Override
@@ -180,9 +180,7 @@ public class FunctionEndpointInitializerTests {
 	protected static class BeansConfiguration {
 		@Bean
 		public BiFunction<String, Map<String, Object>, Map<String, Object>> nullPayload() {
-			return (p, h) -> {
-				return h;
-			};
+			return (p, h) -> h;
 		}
 	}
 
@@ -204,9 +202,7 @@ public class FunctionEndpointInitializerTests {
 		}
 
 		public Function<String, String> reverse() {
-			return s -> {
-				return new StringBuilder(s).reverse().toString();
-			};
+			return s -> new StringBuilder(s).reverse().toString();
 		}
 
 		@Override

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HeadersToMessageTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HeadersToMessageTests.java
@@ -55,6 +55,7 @@ public class HeadersToMessageTests {
 	@Autowired
 	private TestRestTemplate rest;
 
+	@SuppressWarnings("PMD.AvoidRawTypesForCollections")
 	@Test
 	public void testBodyAndCustomHeaderFromMessagePropagation() throws Exception {
 		HttpEntity<Map> postForEntity = this.rest
@@ -68,6 +69,7 @@ public class HeadersToMessageTests {
 		assertThat(postForEntity.getHeaders().get("foo").get(0)).isEqualTo("bar");
 	}
 
+	@SuppressWarnings("PMD.AvoidRawTypesForCollections")
 	@Test
 	public void testHeadersPropagatedByDefault() throws Exception {
 		HttpEntity<Map> postForEntity = this.rest

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpDeleteIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpDeleteIntegrationTests.java
@@ -126,7 +126,7 @@ public class HttpDeleteIntegrationTests {
 		public Consumer<Message<String>> deleteConsumerAsMessage() {
 			return v -> {
 				assertThat(v.getPayload()).isEqualTo("123");
-				assertThat(((Map) v.getHeaders().get("http_request_param")).get("foo")).isEqualTo("bar");
+				assertThat(((Map<String, Object>) v.getHeaders().get("http_request_param")).get("foo")).isEqualTo("bar");
 				System.out.println("Deleting: " + v);
 			};
 		}

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpGetIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpGetIntegrationTests.java
@@ -361,9 +361,7 @@ public class HttpGetIntegrationTests {
 
 		@Bean
 		public Supplier<Flux<String>> timeout() {
-			return () -> Flux.defer(() -> Flux.<String>create(emitter -> {
-				emitter.next("foo");
-			}).timeout(Duration.ofMillis(1000L), Flux.empty()));
+			return () -> Flux.defer(() -> Flux.<String>create(emitter -> emitter.next("foo")).timeout(Duration.ofMillis(1000L), Flux.empty()));
 		}
 
 		@Bean

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpPostIntegrationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/HttpPostIntegrationTests.java
@@ -410,7 +410,7 @@ public class HttpPostIntegrationTests {
 
 		@Bean
 		public Consumer<Flux<String>> updates() {
-			return flux -> flux.subscribe(value -> this.list.add(value));
+			return flux -> flux.subscribe(this.list::add);
 		}
 
 		@Bean
@@ -420,9 +420,7 @@ public class HttpPostIntegrationTests {
 
 		@Bean
 		public Consumer<String> bareUpdates() {
-			return value -> {
-				this.list.add(value);
-			};
+			return this.list::add;
 		}
 
 		@Bean("not/a")

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/MultipartFileTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/MultipartFileTests.java
@@ -58,7 +58,7 @@ public class MultipartFileTests {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
-		HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<LinkedMultiValueMap<String, Object>>(
+		HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<>(
 				map, headers);
 		ResponseEntity<String> result = template.exchange(new URI("http://localhost:" + port + "/uppercase"),
 				HttpMethod.POST, requestEntity, String.class);
@@ -79,7 +79,7 @@ public class MultipartFileTests {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
-		HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<LinkedMultiValueMap<String, Object>>(
+		HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<>(
 				map, headers);
 		ResponseEntity<String> result = template.exchange(new URI("http://localhost:" + port + "/uppercase"),
 				HttpMethod.POST, requestEntity, String.class);
@@ -93,9 +93,7 @@ public class MultipartFileTests {
 
 		@Bean
 		public Function<MultipartFile, String> uppercase() {
-			return value -> {
-				return value.getOriginalFilename().toUpperCase(Locale.ROOT);
-			};
+			return value -> value.getOriginalFilename().toUpperCase(Locale.ROOT);
 		}
 	}
 }

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/RoutingFunctionTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/mvc/RoutingFunctionTests.java
@@ -219,9 +219,7 @@ public class RoutingFunctionTests {
 
 		@Bean
 		public Consumer<Flux<String>> fluxconsumer() {
-			return flux -> flux.doOnNext(s -> {
-				System.out.println("Received: " + s);
-			}).subscribe();
+			return flux -> flux.doOnNext(s -> System.out.println("Received: " + s)).subscribe();
 		}
 
 		@Bean

--- a/src/checkstyle/pmd-modern-java.xml
+++ b/src/checkstyle/pmd-modern-java.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0"?>
+<ruleset name="Spring Cloud Function Modernization Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+	<description>Rules to encourage modern Java 17+ syntax conventions</description>
+
+	<!-- 1. Diamond Operator (Built-in rule) -->
+	<rule ref="category/java/codestyle.xml/UseDiamondOperator">
+		<priority>4</priority>
+	</rule>
+
+	<!-- 1a. Lambda can be Method Reference (Built-in rule) -->
+	<rule ref="category/java/codestyle.xml/LambdaCanBeMethodReference">
+		<priority>4</priority>
+	</rule>
+
+	<!-- 2. Avoid Raw Types for Collections -->
+	<rule name="AvoidRawTypesForCollections"
+	      language="java"
+	      message="Consider using parameterized types instead of raw types for collections (e.g., List&lt;Object&gt;). Suppress with @SuppressWarnings(&quot;PMD.AvoidRawTypesForCollections&quot;) if intentional."
+	      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+		<description>
+			Encourages the use of generics over raw types for standard collections to ensure type safety.
+			Class literals, nested generic types (e.g., Map.Entry), instanceof checks and casts are excluded
+			as they are not raw type usage in the sense of this rule.
+		</description>
+		<priority>4</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+					<![CDATA[
+					//ClassType[
+						(@SimpleName='List' or @SimpleName='Set' or @SimpleName='Map' or
+						 @SimpleName='ArrayList' or @SimpleName='HashMap' or @SimpleName='HashSet' or
+						 @SimpleName='Queue' or @SimpleName='Collection' or @SimpleName='Optional')
+						and not(TypeArguments)
+						and not(parent::ClassLiteral)
+						and not(parent::ClassType)
+						and not(ancestor::PatternExpression)
+						and not(ancestor::TypeExpression)
+						and not(ancestor::CastExpression)
+					]
+					]]>
+				</value>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- 2a. Pattern Matching for instanceof (Java 16+) -->
+	<rule name="PreferPatternMatchingForInstanceof"
+	      language="java"
+	      message="Consider using Java 16+ pattern matching for 'instanceof' to avoid explicit casting."
+	      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+		<description>
+			Identifies 'instanceof' checks followed by an explicit cast of the same expression to the same type
+			within the if-block, which can be simplified using pattern matching.
+		</description>
+		<priority>4</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+					<![CDATA[
+					//IfStatement[
+						InfixExpression[@Operator='instanceof']
+					]/Block//CastExpression[
+						VariableAccess/@Name = ancestor::IfStatement[1]/InfixExpression[@Operator='instanceof']/VariableAccess/@Name
+						and ClassType[@SimpleName = ancestor::IfStatement[1]/InfixExpression[@Operator='instanceof']//ClassType/@SimpleName]
+						and not(ClassType/TypeArguments)
+					]
+					]]>
+				</value>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- 3. Simplify Lambda Body -->
+	<rule name="SimplifyLambdaBlock"
+	      language="java"
+	      message="Consider simplifying this single-statement lambda block. Braces and 'return' might be redundant."
+	      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+		<description>
+			Lambdas with a single statement in their block can often be simplified to expression lambdas or method
+			references.
+		</description>
+		<priority>4</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+					<![CDATA[
+					//LambdaExpression/Block[
+						count(*) = 1 and
+						(*[self::ReturnStatement or self::ExpressionStatement])
+					]
+					]]>
+				</value>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- 4. Simple Classes -> Records (Java 16+) -->
+	<rule name="ConsiderUsingRecord"
+	      language="java"
+	      message="Consider converting this private static class to a Java 16+ Record, as it appears to be an immutable data carrier."
+	      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+		<description>
+			Identifies private static classes with only final fields, which are good candidates for Java Records.
+		</description>
+		<priority>5</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+					<![CDATA[
+					//ClassDeclaration[
+						@Interface=false() and
+						@Visibility='private' and
+						@Static=true() and
+						@Abstract=false() and
+						not(ExtendsList)
+					]/ClassBody[
+						count(FieldDeclaration) > 0 and
+						count(FieldDeclaration/VariableDeclarator/VariableId[@Final=false()]) = 0 and
+						count(ConstructorDeclaration) = 0
+					]
+					]]>
+				</value>
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>


### PR DESCRIPTION
Hi @olegz!

I wanted to keep the maintenance momentum going, so this PR modernizes the codebase to Java 17 conventions and adds a tool to make sure it stays that way.

The first part is the modernization itself, across all modules:

- Replaced instanceof + cast pairs with pattern matching (Java 16+)
- Converted simple private static data carriers to records
- Replaced anonymous classes with lambdas and method references
- Simplified single-statement lambda blocks
- Used diamond operator where the type is inferable
- Replaced raw types with parameterized ones where possible

The second part adds a report-only PMD 7 profile:

New -Ppmd profile runs pmd:check at verify with failOnViolation=false, so it prints hints but never breaks the build.
Custom ruleset covering the same modernization themes, calibrated against the codebase to avoid false positives.
The tool already paid for itself - it found 43 instanceof + cast spots the manual pass had missed.
The profile reports zero violations on the current codebase after the refactoring.

One modernization theme is intentionally missing from the ruleset, though: anonymous classes to lambdas. The syntactic heuristic (single method, no fields) would also flag anonymous subclasses of abstract classes like new `FunctionAroundWrapper() { ... }`, which are not convertible - only implementations of functional interfaces are. Telling those apart requires checking whether the supertype is a functional interface, and PMD's XPath rules have no way to ask that about a resolved type. Shipping the rule as-is meant firing on every legitimate abstract class subclass, so I dropped it rather than adding noise. If PMD ever gains a functional-interface check, this rule would be a nice addition.

I also did a (AI-assisted :D) backward compatibility review of the public API before opening this PR. The changes are all limited to method internals: the records were created only from private and package-private classes, no public signatures, fields, constants or visibility were touched, and the pattern matching conversions are semantically equivalent to the casts they replace - the one spot where a variable gets reassigned mid-block was deliberately left unconverted. So client code should be unaffected, but I'd appreciate a second pair of eyes on that - let me know if anything looks off.

Hope this may be useful!