### PR TITLE
Update Maven wrapper to 3.9.16

### DIFF
--- a/spring-cloud-function-samples/function-sample-aws-native/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-aws-native/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-aws-serverless-web-native/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-aws-serverless-web-native/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.7/apache-maven-3.8.7-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-azure-blob-trigger/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-azure-blob-trigger/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-azure-eventgrid-trigger/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-azure-eventgrid-trigger/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-azure-http-trigger/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-azure-http-trigger/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-azure-time-trigger/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-azure-time-trigger/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-azure-web/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-azure-web/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-cloudevent-sdk/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-cloudevent-sdk/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-cloudevent-stream/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-cloudevent-stream/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-cloudevent/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-cloudevent/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-grpc-cloudevent/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-grpc-cloudevent/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.2/apache-maven-3.8.2-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/spring-cloud-function-samples/function-sample-kotlin-web/.mvn/wrapper/maven-wrapper.properties
+++ b/spring-cloud-function-samples/function-sample-kotlin-web/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar


### PR DESCRIPTION
Updates the module Maven wrappers on `main` to Maven **3.9.16** and `maven-wrapper` **3.3.4**.

Files changed (12):

- `spring-cloud-function-samples/function-sample-aws-native/.mvn/wrapper/maven-wrapper.properties` — Maven 3.8.6 → 3.9.16
- `spring-cloud-function-samples/function-sample-aws-serverless-web-native/.mvn/wrapper/maven-wrapper.properties` — Maven 3.8.7 → 3.9.16
- `spring-cloud-function-samples/function-sample-azure-blob-trigger/.mvn/wrapper/maven-wrapper.properties` — Maven 3.8.6 → 3.9.16
- `spring-cloud-function-samples/function-sample-azure-eventgrid-trigger/.mvn/wrapper/maven-wrapper.properties` — Maven 3.6.3 → 3.9.16
- `spring-cloud-function-samples/function-sample-azure-http-trigger/.mvn/wrapper/maven-wrapper.properties` — Maven 3.8.6 → 3.9.16
- `spring-cloud-function-samples/function-sample-azure-time-trigger/.mvn/wrapper/maven-wrapper.properties` — Maven 3.8.6 → 3.9.16
- `spring-cloud-function-samples/function-sample-azure-web/.mvn/wrapper/maven-wrapper.properties` — Maven 3.9.3 → 3.9.16
- `spring-cloud-function-samples/function-sample-cloudevent/.mvn/wrapper/maven-wrapper.properties` — Maven 3.6.3 → 3.9.16
- `spring-cloud-function-samples/function-sample-cloudevent-sdk/.mvn/wrapper/maven-wrapper.properties` — Maven 3.6.3 → 3.9.16
- `spring-cloud-function-samples/function-sample-cloudevent-stream/.mvn/wrapper/maven-wrapper.properties` — Maven 3.6.3 → 3.9.16
- `spring-cloud-function-samples/function-sample-grpc-cloudevent/.mvn/wrapper/maven-wrapper.properties` — Maven 3.8.2 → 3.9.16
- `spring-cloud-function-samples/function-sample-kotlin-web/.mvn/wrapper/maven-wrapper.properties` — Maven 3.6.3 → 3.9.16

Opened automatically by [update-maven-wrapper.yml](https://github.com/spring-cloud/spring-cloud-github-actions/blob/main/.github/workflows/update-maven-wrapper.yml).

Keeping the wrapper current stops Dependabot from trying to update it itself, which currently fails - it shells out to `mvn wrapper:wrapper`, which cannot resolve an unpublished SNAPSHOT parent POM, and it cannot parse the older wrapper formats.

Module wrappers are included because Dependabot reads the wrapper in the directory of *every* pom it fetches, and a single unreadable one aborts the whole repository's update job - not merely the wrapper update.