### PR TITLE
fix(cloudevent): honor target-protocol for Kafka ce_ prefix

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtils.java
@@ -22,6 +22,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -370,6 +371,10 @@ public final class CloudEventMessageUtils {
 	}
 
 	static String extractTargetProtocol(Map<String, Object> messageHeaders) {
+		String targetProtocol = resolveTargetProtocolHeader(messageHeaders);
+		if (StringUtils.hasText(targetProtocol)) {
+			return targetProtocol;
+		}
 		Iterator<String> keyIterator = messageHeaders.keySet().iterator();
 		for (; keyIterator.hasNext();) {
 			String key = keyIterator.next();
@@ -379,6 +384,22 @@ public final class CloudEventMessageUtils {
 			else if (key.startsWith("amqp")) {
 				return Protocols.AMQP;
 			}
+		}
+		return null;
+	}
+
+	private static String resolveTargetProtocolHeader(Map<String, Object> messageHeaders) {
+		Object targetProtocol = messageHeaders.get(MessageUtils.TARGET_PROTOCOL);
+		if (targetProtocol == null) {
+			for (Map.Entry<String, Object> entry : messageHeaders.entrySet()) {
+				if (MessageUtils.TARGET_PROTOCOL.equalsIgnoreCase(entry.getKey())) {
+					targetProtocol = entry.getValue();
+					break;
+				}
+			}
+		}
+		if (targetProtocol instanceof String protocol && StringUtils.hasText(protocol)) {
+			return protocol.toLowerCase(Locale.ROOT);
 		}
 		return null;
 	}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionInvocationHelper.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/cloudevent/CloudEventsFunctionInvocationHelper.java
@@ -17,6 +17,8 @@
 package org.springframework.cloud.function.cloudevent;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.logging.Log;
@@ -99,7 +101,8 @@ public class CloudEventsFunctionInvocationHelper implements FunctionInvocationHe
 
 		String targetPrefix = CloudEventMessageUtils.DEFAULT_ATTR_PREFIX;
 		if (input != null) {
-			targetPrefix = CloudEventMessageUtils.determinePrefixToUse(input.getHeaders(), true);
+			targetPrefix = CloudEventMessageUtils.determinePrefixToUse(
+					headersForTargetPrefix(input, result), true);
 		}
 		else if (result instanceof Message resultMessage) {
 			targetPrefix = CloudEventMessageUtils.determinePrefixToUse(resultMessage.getHeaders(), true);
@@ -117,6 +120,19 @@ public class CloudEventsFunctionInvocationHelper implements FunctionInvocationHe
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+	}
+
+
+	private static Map<String, Object> headersForTargetPrefix(Message<?> input, Object result) {
+		Map<String, Object> headers = new HashMap<>(input.getHeaders());
+		if (result instanceof Message<?> resultMessage) {
+			resultMessage.getHeaders().forEach((key, value) -> {
+				if (value != null) {
+					headers.putIfAbsent(key, value);
+				}
+			});
+		}
+		return headers;
 	}
 
 	private Message<?> doPostProcessResult(Object result, String targetPrefix) {

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/message/MessageUtils.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/message/MessageUtils.java
@@ -32,7 +32,12 @@ public abstract class MessageUtils {
 	 */
 	public static String MESSAGE_TYPE = "message-type";
 	/**
-	 * Value for 'target-protocol' typically use as header key.
+	 * Header key for the target messaging protocol of an outgoing Cloud Event (e.g. kafka, amqp, http).
+	 */
+	public static String TARGET_PROTOCOL = "target-protocol";
+
+	/**
+	 * Value for 'source-type' typically use as header key.
 	 */
 	public static String SOURCE_TYPE = "source-type";
 

--- a/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtilsAndBuilderTests.java
+++ b/spring-cloud-function-context/src/test/java/org/springframework/cloud/function/cloudevent/CloudEventMessageUtilsAndBuilderTests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.cloud.function.context.message.MessageUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 
@@ -96,6 +97,20 @@ public class CloudEventMessageUtilsAndBuilderTests {
 		assertThat(CloudEventMessageUtils.getType(httpMessage)).isEqualTo("blah");
 		assertThat(httpMessage.getHeaders().get("ce-specversion")).isNotNull();
 		assertThat(CloudEventMessageUtils.getSpecVersion(httpMessage)).isEqualTo("1.0");
+	}
+
+
+	@Test
+	void determinePrefixToUsePrefersTargetProtocolHeaderOverSourceProtocolHeaders() {
+		Message<String> ceMessage = CloudEventMessageBuilder.withData("foo")
+				.build(CloudEventMessageUtils.AMQP_ATTR_PREFIX);
+		ceMessage = MessageBuilder.fromMessage(ceMessage)
+				.setHeader(MessageUtils.TARGET_PROTOCOL, "kafka")
+				.setHeader("amqp_correlationId", "123")
+				.build();
+
+		assertThat(CloudEventMessageUtils.determinePrefixToUse(ceMessage.getHeaders(), true))
+				.isEqualTo(CloudEventMessageUtils.KAFKA_ATTR_PREFIX);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Restores `MessageUtils.TARGET_PROTOCOL` and resolves the `target-protocol` header (case-insensitive) before inferring protocol from `kafka_*` / `amqp` headers in `CloudEventMessageUtils.extractTargetProtocol`.
- Merges input and result headers in `CloudEventsFunctionInvocationHelper.postProcessResult` when choosing the output Cloud Event attribute prefix.
- Adds a unit test covering AMQP-sourced messages with `target-protocol: kafka` (cross-binder scenario from gh-1461).

Fixes gh-1461

## Context

Since gh-1294 / spring-cloud/spring-cloud-stream#2222, Spring Cloud Stream no longer sets `target-protocol` on messages, and prefix detection falls back to binder-specific headers on the **input** message. For AMQP → Kafka flows (e.g. `function-sample-cloudevent-stream`), that yields `cloudEvents:` on Kafka instead of `ce_`.

This change restores the function-side support for `target-protocol`. **Spring Cloud Stream should restore setting that header** on function input (see commented lines in `FunctionConfiguration.FunctionWrapper#setHeadersIfNeeded` and the reactive `targetProtocolEnhancer`) so end-to-end behavior matches the sample README again.

## Test plan

- [x] `./mvnw -pl spring-cloud-function-context -am test`
- [ ] `./mvnw -f spring-cloud-function-samples/function-sample-cloudevent-stream/pom.xml test` (module not in parent reactor; requires Rabbit/Kafka on localhost; `DemoApplicationTests#test` is currently commented out)
- [ ] After stream companion change: enable `DemoApplicationTests#test` and verify Kafka headers use `ce_` prefix